### PR TITLE
[core] fix: update json smart

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>1.3.3</version>
+            <version>2.4.8</version>
         </dependency>
 
         <dependency>

--- a/core/src/test/java/org/nem/core/connect/HttpMethodClientTest.java
+++ b/core/src/test/java/org/nem/core/connect/HttpMethodClientTest.java
@@ -73,7 +73,7 @@ public class HttpMethodClientTest {
 
 			// Assert: this should fail because the underlying client is closed
 			ExceptionAssert.assertThrows(v -> this.strategy.send(client, this.stringToUrl(GOOD_URL), DEFAULT_STRATEGY).get(),
-					IllegalStateException.class);
+					FatalPeerException.class);
 		}
 
 		@Test

--- a/core/src/test/java/org/nem/core/model/NemesisBlockTest.java
+++ b/core/src/test/java/org/nem/core/model/NemesisBlockTest.java
@@ -203,7 +203,7 @@ public class NemesisBlockTest {
 
 		private static JSONObject loadNemesisBlockJsonObject() {
 			try (final InputStream fin = NemesisBlock.class.getClassLoader().getResourceAsStream("nemesis-testnet.json")) {
-				return (JSONObject) JSONValue.parseStrict(fin);
+				return (JSONObject) JSONValue.parseStrict(new InputStreamReader(fin));
 			} catch (IOException | net.minidev.json.parser.ParseException e) {
 				Assert.fail("unexpected exception was thrown when parsing nemesis block resource");
 				throw new RuntimeException(e);


### PR DESCRIPTION
1. Bump json-smart from 1.3.3 to 2.4.8
2. Fix failing tests