### PR TITLE
[monorepo] fix: add threshold for code coverage drop

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -8,21 +8,25 @@ coverage:
 
       nem-core:
         target: auto
+        threshold: 1%
         flags:
           - nem-core
 
       nem-deploy:
         target: auto
+        threshold: 1%
         flags:
           - nem-deploy
 
       nem-nis:
         target: auto
+        threshold: 1%
         flags:
           - nem-nis
 
       nem-peer:
         target: auto
+        threshold: 1%
         flags:
           - nem-peer
 


### PR DESCRIPTION
 problem: code coverage checks will fail due to a small drop in percentage.
solution: Allow a drop of up to 1% in code coverage.