### PR TITLE
[monorepo] fix: move nightly builds to bulid configuration file

### DIFF
--- a/.github/buildConfiguration.yaml
+++ b/.github/buildConfiguration.yaml
@@ -18,3 +18,11 @@ builds:
       - core
       - deploy
       - peer
+
+customBuilds:
+  - name: Nightly Job
+    jobName: nightlyJob
+    scriptPath: .github/jenkinsfile/nightlyBuild.groovy
+    triggers:
+      - type: cron
+        schedule: '@midnight'


### PR DESCRIPTION
problem: nightly build properties was in the code.
solution: move nightly job to the buildconfiguration file.