### PR TITLE
[nis] feat: allow fork height override

### DIFF
--- a/nis/src/main/java/org/nem/nis/BlockAnalyzer.java
+++ b/nis/src/main/java/org/nem/nis/BlockAnalyzer.java
@@ -33,26 +33,29 @@ public class BlockAnalyzer {
 	private final NisMapperFactory mapperFactory;
 	private final NemesisBlockInfo nemesisBlockInfo;
 	private final int estimatedBlocksPerYear;
+	private final ForkConfiguration forkConfiguration;
 
 	/**
 	 * Creates a new block analyzer.
 	 *
 	 * @param blockDao The block dao.
-	 * @param blockChainScoreManager The block chain score manager.
-	 * @param blockChainLastBlockLayer The block chain last block layer.
+	 * @param blockChainScoreManager The blockchain score manager.
+	 * @param blockChainLastBlockLayer The blockchain last block layer.
 	 * @param mapperFactory The mapper factory.
 	 * @param estimatedBlocksPerYear The estimated number of blocks per year.
+	 * @param forkConfiguration The fork configuration.
 	 */
 	@Autowired(required = true)
 	public BlockAnalyzer(final BlockDao blockDao, final BlockChainScoreManager blockChainScoreManager,
 			final BlockChainLastBlockLayer blockChainLastBlockLayer, final NisMapperFactory mapperFactory,
-			final int estimatedBlocksPerYear) {
+			final int estimatedBlocksPerYear, final ForkConfiguration forkConfiguration) {
 		this.blockDao = blockDao;
 		this.blockChainScoreManager = blockChainScoreManager;
 		this.blockChainLastBlockLayer = blockChainLastBlockLayer;
 		this.mapperFactory = mapperFactory;
 		this.nemesisBlockInfo = NetworkInfos.getDefault().getNemesisBlockInfo();
 		this.estimatedBlocksPerYear = estimatedBlocksPerYear;
+		this.forkConfiguration = forkConfiguration;
 	}
 
 	/**
@@ -97,7 +100,8 @@ public class BlockAnalyzer {
 
 		final AccountCache accountCache = nisCache.getAccountCache();
 		final BlockExecutor executor = new BlockExecutor(nisCache);
-		final BlockTransactionObserver observer = new BlockTransactionObserverFactory(options, this.estimatedBlocksPerYear)
+		final BlockTransactionObserver observer = new BlockTransactionObserverFactory(options, this.estimatedBlocksPerYear,
+				this.forkConfiguration)
 				.createExecuteCommitObserver(nisCache);
 		final NisDbModelToModelMapper mapper = this.mapperFactory.createDbModelToModelNisMapper(accountCache);
 

--- a/nis/src/main/java/org/nem/nis/BlockAnalyzer.java
+++ b/nis/src/main/java/org/nem/nis/BlockAnalyzer.java
@@ -47,8 +47,8 @@ public class BlockAnalyzer {
 	 */
 	@Autowired(required = true)
 	public BlockAnalyzer(final BlockDao blockDao, final BlockChainScoreManager blockChainScoreManager,
-			final BlockChainLastBlockLayer blockChainLastBlockLayer, final NisMapperFactory mapperFactory,
-			final int estimatedBlocksPerYear, final ForkConfiguration forkConfiguration) {
+			final BlockChainLastBlockLayer blockChainLastBlockLayer, final NisMapperFactory mapperFactory, final int estimatedBlocksPerYear,
+			final ForkConfiguration forkConfiguration) {
 		this.blockDao = blockDao;
 		this.blockChainScoreManager = blockChainScoreManager;
 		this.blockChainLastBlockLayer = blockChainLastBlockLayer;
@@ -101,8 +101,7 @@ public class BlockAnalyzer {
 		final AccountCache accountCache = nisCache.getAccountCache();
 		final BlockExecutor executor = new BlockExecutor(nisCache);
 		final BlockTransactionObserver observer = new BlockTransactionObserverFactory(options, this.estimatedBlocksPerYear,
-				this.forkConfiguration)
-				.createExecuteCommitObserver(nisCache);
+				this.forkConfiguration).createExecuteCommitObserver(nisCache);
 		final NisDbModelToModelMapper mapper = this.mapperFactory.createDbModelToModelNisMapper(accountCache);
 
 		do {

--- a/nis/src/main/java/org/nem/nis/FeeFork.java
+++ b/nis/src/main/java/org/nem/nis/FeeFork.java
@@ -3,19 +3,19 @@ package org.nem.nis;
 import org.nem.core.model.primitive.BlockHeight;
 
 /**
- * DTO for the fee fork heights.
+ * DTO for the fee fork.
  */
-public class FeeForkDto {
+public class FeeFork {
 	public final BlockHeight firstHeight;
 	public final BlockHeight secondHeight;
 
 	/**
-	 * Creates a fee fork heights.
+	 * Creates a fee fork dto.
 	 *
 	 * @param firstHeight The first fee fork height.
 	 * @param secondHeight The second fee fork height.
 	 */
-	public FeeForkDto(final BlockHeight firstHeight, final BlockHeight secondHeight) {
+	public FeeFork(final BlockHeight firstHeight, final BlockHeight secondHeight) {
 		this.firstHeight = firstHeight;
 		this.secondHeight = secondHeight;
 	}

--- a/nis/src/main/java/org/nem/nis/FeeForkDto.java
+++ b/nis/src/main/java/org/nem/nis/FeeForkDto.java
@@ -1,0 +1,40 @@
+package org.nem.nis;
+
+import org.nem.core.model.primitive.BlockHeight;
+
+/**
+ * DTO for the fee fork heights.
+ */
+public class FeeForkDto {
+	public final BlockHeight firstHeight;
+	public final BlockHeight secondHeight;
+
+	/**
+	 * Creates a fee fork heights.
+	 *
+	 * @param firstHeight The first fee fork height.
+	 * @param secondHeight The second fee fork height.
+	 */
+	public FeeForkDto(final BlockHeight firstHeight, final BlockHeight secondHeight) {
+		this.firstHeight = firstHeight;
+		this.secondHeight = secondHeight;
+	}
+
+	/**
+	 * Gets the first fee fork height.
+	 *
+	 * @return The first fee fork height.
+	 */
+	public BlockHeight getFirstHeight() {
+		return this.firstHeight;
+	}
+
+	/**
+	 * Gets the second fee fork height.
+	 *
+	 * @return The second fee fork height.
+	 */
+	public BlockHeight getSecondHeight() {
+		return this.secondHeight;
+	}
+}

--- a/nis/src/main/java/org/nem/nis/ForkConfiguration.java
+++ b/nis/src/main/java/org/nem/nis/ForkConfiguration.java
@@ -2,6 +2,7 @@ package org.nem.nis;
 
 import org.nem.core.crypto.Hash;
 import org.nem.core.model.NemProperties;
+import org.nem.core.model.NetworkInfos;
 import org.nem.core.model.primitive.BlockHeight;
 
 import java.util.*;
@@ -15,46 +16,23 @@ public class ForkConfiguration {
 	private final List<Hash> treasuryReissuanceForkTransactionHashes;
 	private final List<Hash> treasuryReissuanceForkFallbackTransactionHashes;
 
-	/**
-	 * Creates a new default configuration object.
-	 */
-	public ForkConfiguration() {
-		this(new BlockHeight(1), new ArrayList<Hash>(), new ArrayList<Hash>());
-	}
+	private final BlockHeight multisigMOfNForkHeight;
+	private final BlockHeight mosaicsForkHeight;
+	private final BlockHeight feeForkHeight;
+	private final BlockHeight remoteAccountForkHeight;
+	private final BlockHeight mosaicRedefinitionForkHeight;
+	private final BlockHeight secondFeeForkHeight;
 
-	/**
-	 * Creates a new configuration object around the specified properties.
-	 *
-	 * @param treasuryReissuanceForkHeight The height of the fork at which to reissue the treasury.
-	 * @param treasuryReissuanceForkTransactionHashes The hashes of transactions that are allowed in the treasury reissuance fork block
-	 *            (preferred).
-	 * @param treasuryReissuanceForkFallbackTransactionHashes The hashes of transactions that are allowed in the treasury reissuance fork
-	 *            block (fallback).
-	 */
-	public ForkConfiguration(final BlockHeight treasuryReissuanceForkHeight, final List<Hash> treasuryReissuanceForkTransactionHashes,
-			final List<Hash> treasuryReissuanceForkFallbackTransactionHashes) {
-		this.treasuryReissuanceForkHeight = treasuryReissuanceForkHeight;
-		this.treasuryReissuanceForkTransactionHashes = Collections.unmodifiableList(treasuryReissuanceForkTransactionHashes);
-		this.treasuryReissuanceForkFallbackTransactionHashes = Collections
-				.unmodifiableList(treasuryReissuanceForkFallbackTransactionHashes);
-	}
-
-	/**
-	 * Creates a new configuration object around the specified properties.
-	 *
-	 * @param properties The specified properties.
-	 */
-	public ForkConfiguration(final NemProperties properties) {
-		this.treasuryReissuanceForkHeight = new BlockHeight(properties.getOptionalInteger("nis.treasuryReissuanceForkHeight", 1));
-		this.treasuryReissuanceForkTransactionHashes = Collections
-				.unmodifiableList(ForkConfiguration.parseHashes(properties, "nis.treasuryReissuanceForkTransactionHashes"));
-		this.treasuryReissuanceForkFallbackTransactionHashes = Collections
-				.unmodifiableList(ForkConfiguration.parseHashes(properties, "nis.treasuryReissuanceForkFallbackTransactionHashes"));
-	}
-
-	private static List<Hash> parseHashes(final NemProperties properties, final String propertyName) {
-		return Arrays.stream(properties.getOptionalStringArray(propertyName, "")).map(s -> Hash.fromHexString(s.trim()))
-				.collect(Collectors.toList());
+	private ForkConfiguration(final Builder builder) {
+		this.treasuryReissuanceForkHeight = builder.treasuryReissuanceForkHeight;
+		this.treasuryReissuanceForkTransactionHashes = builder.treasuryReissuanceForkTransactionHashes;
+		this.treasuryReissuanceForkFallbackTransactionHashes = builder.treasuryReissuanceForkFallbackTransactionHashes;
+		this.multisigMOfNForkHeight = builder.multisigMOfNForkHeight;
+		this.mosaicsForkHeight = builder.mosaicsForkHeight;
+		this.feeForkHeight = builder.feeForkHeight;
+		this.remoteAccountForkHeight = builder.remoteAccountForkHeight;
+		this.mosaicRedefinitionForkHeight = builder.mosaicRedefinitionForkHeight;
+		this.secondFeeForkHeight = builder.secondFeeForkHeight;
 	}
 
 	/**
@@ -82,5 +60,223 @@ public class ForkConfiguration {
 	 */
 	public Collection<Hash> getTreasuryReissuanceForkFallbackTransactionHashes() {
 		return this.treasuryReissuanceForkFallbackTransactionHashes;
+	}
+
+	/**
+	 * Gets the height of the fork at which to enable multisig M-of-N.
+	 *
+	 * @return The height of the fork.
+	 */
+	public BlockHeight getmultisigMOfNForkHeight() {
+		return this.multisigMOfNForkHeight;
+	}
+
+	/**
+	 * Gets the height of the mosaics fork.
+	 *
+	 * @return The height of the fork.
+	 */
+	public BlockHeight getMosaicsForkHeight() {
+		return this.mosaicsForkHeight;
+	}
+
+	/**
+	 * Gets the height of the fee fork.
+	 *
+	 * @return The height of the fork.
+	 */
+
+	public BlockHeight getFeeForkHeight() {
+		return this.feeForkHeight;
+	}
+
+	/**
+	 * Gets the height of the remote account fork.
+	 *
+	 * @return The height of the fork.
+	 */
+	public BlockHeight getRemoteAccountForkHeight() {
+		return this.remoteAccountForkHeight;
+	}
+
+	/**
+	 * Gets the height of the mosaic redefinition fork.
+	 *
+	 * @return The height of the fork.
+	 */
+	public BlockHeight getMosaicRedefinitionForkHeight() {
+		return this.mosaicRedefinitionForkHeight;
+	}
+
+	/**
+	 * Gets the height of the second fee fork.
+	 *
+	 * @return The height of the fork.
+	 */
+	public BlockHeight getSecondFeeForkHeight() {
+		return this.secondFeeForkHeight;
+	}
+
+	/**
+	 * Creates a builder for a fork configuration.
+	 */
+	public static class Builder {
+		private BlockHeight treasuryReissuanceForkHeight;
+		private List<Hash> treasuryReissuanceForkTransactionHashes;
+		private List<Hash> treasuryReissuanceForkFallbackTransactionHashes;
+		private BlockHeight multisigMOfNForkHeight;
+		private BlockHeight mosaicsForkHeight;
+		private BlockHeight feeForkHeight;
+		private BlockHeight remoteAccountForkHeight;
+		private BlockHeight mosaicRedefinitionForkHeight;
+		private BlockHeight secondFeeForkHeight;
+
+		/**
+		 * Creates the default builder.
+		 */
+		public Builder() {
+			final int version = NetworkInfos.getDefault().getVersion() << 24;
+			treasuryReissuanceForkHeight = new BlockHeight(1);
+			treasuryReissuanceForkTransactionHashes = Collections.emptyList();
+			treasuryReissuanceForkFallbackTransactionHashes = Collections.emptyList();
+			multisigMOfNForkHeight = new BlockHeight(BlockMarkerConstants.MULTISIG_M_OF_N_FORK(version));
+			mosaicsForkHeight = new BlockHeight(BlockMarkerConstants.MOSAICS_FORK(version));
+			feeForkHeight = new BlockHeight(BlockMarkerConstants.FEE_FORK(version));
+			remoteAccountForkHeight = new BlockHeight(BlockMarkerConstants.REMOTE_ACCOUNT_FORK(version));
+			mosaicRedefinitionForkHeight = new BlockHeight(BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(version));
+			secondFeeForkHeight = new BlockHeight(BlockMarkerConstants.SECOND_FEE_FORK(version));
+		}
+
+		/**
+		 * Creates a builder for a fork configuration from nis configuration.
+		 *
+		 * @param properties nis properties.
+		 */
+		public Builder(final NemProperties properties) {
+			final int version = NetworkInfos.getDefault().getVersion() << 24;
+			this.treasuryReissuanceForkHeight = new BlockHeight(properties.getOptionalInteger("nis.treasuryReissuanceForkHeight", 1));
+			this.treasuryReissuanceForkTransactionHashes = Collections
+					.unmodifiableList(parseHashes(properties, "nis.treasuryReissuanceForkTransactionHashes"));
+			this.treasuryReissuanceForkFallbackTransactionHashes = Collections
+					.unmodifiableList(parseHashes(properties, "nis.treasuryReissuanceForkFallbackTransactionHashes"));
+
+			this.multisigMOfNForkHeight = new BlockHeight(properties.getOptionalLong("nis.multisigMOfNForkHeight",
+					BlockMarkerConstants.MULTISIG_M_OF_N_FORK(version)));
+			this.mosaicsForkHeight = new BlockHeight(properties.getOptionalLong("nis.mosaicsForkHeight",
+					BlockMarkerConstants.MOSAICS_FORK(version)));
+			this.feeForkHeight = new BlockHeight(properties.getOptionalLong("nis.feeForkHeight",
+					BlockMarkerConstants.FEE_FORK(version)));
+			this.remoteAccountForkHeight = new BlockHeight(properties.getOptionalLong("nis.remoteAccountForkHeight",
+					BlockMarkerConstants.REMOTE_ACCOUNT_FORK(version)));
+			this.mosaicRedefinitionForkHeight = new BlockHeight(properties.getOptionalLong("nis.mosaicRedefinitionForkHeight",
+					BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(version)));
+			this.secondFeeForkHeight = new BlockHeight(properties.getOptionalLong("nis.secondFeeForkHeight",
+					BlockMarkerConstants.SECOND_FEE_FORK(version)));
+		}
+
+		private static List<Hash> parseHashes(final NemProperties properties, final String propertyName) {
+			return Arrays.stream(properties.getOptionalStringArray(propertyName, "")).map(s -> Hash.fromHexString(s.trim()))
+					.collect(Collectors.toList());
+		}
+
+		/**
+		 * Sets the treasury reissuance fork height
+		 *
+		 * @return The fork configuration builder.
+		 */
+		public Builder treasuryReissuanceForkHeight(final BlockHeight treasuryReissuanceForkHeight) {
+			this.treasuryReissuanceForkHeight = treasuryReissuanceForkHeight;
+			return this;
+		}
+
+		/**
+		 * Sets the treasury reissuance fork transaction hashes
+		 *
+		 * @return The fork configuration builder.
+		 */
+		public Builder treasuryReissuanceForkTransactionHashes(final List<Hash> treasuryReissuanceForkTransactionHashes) {
+			this.treasuryReissuanceForkTransactionHashes = treasuryReissuanceForkTransactionHashes;
+			return this;
+		}
+
+		/**
+		 * Sets the treasury reissuance fork fallback transaction hashes
+		 *
+		 * @return The fork configuration builder.
+		 */
+		public Builder treasuryReissuanceForkFallbackTransactionHashes(
+				final List<Hash> treasuryReissuanceForkFallbackTransactionHashes) {
+			this.treasuryReissuanceForkFallbackTransactionHashes = treasuryReissuanceForkFallbackTransactionHashes;
+			return this;
+		}
+
+		/**
+		 * Sets the multisig m-of-n fork height
+		 *
+		 * @return The fork configuration builder.
+		 */
+		public Builder multisigMOfNForkHeight(final BlockHeight multisigMOfNForkHeight) {
+			this.multisigMOfNForkHeight = multisigMOfNForkHeight;
+			return this;
+		}
+
+		/**
+		 * Sets the mosaics fork height
+		 *
+		 * @return The fork configuration builder.
+		 */
+		public Builder mosaicsForkHeight(final BlockHeight mosaicsForkHeight) {
+			this.mosaicsForkHeight = mosaicsForkHeight;
+			return this;
+		}
+
+		/**
+		 * Sets the fee fork height
+		 *
+		 * @return The fork configuration builder.
+		 */
+		public Builder feeForkHeight(final BlockHeight feeForkHeight) {
+			this.feeForkHeight = feeForkHeight;
+			return this;
+		}
+
+		/**
+		 * Sets the remote account fork height
+		 *
+		 * @return The fork configuration builder.
+		 */
+		public Builder remoteAccountForkHeight(final BlockHeight remoteAccountForkHeight) {
+			this.remoteAccountForkHeight = remoteAccountForkHeight;
+			return this;
+		}
+
+		/**
+		 * Sets the mosaic redefinition fork height
+		 *
+		 * @return The fork configuration builder.
+		 */
+		public Builder mosaicRedefinitionForkHeight(final BlockHeight mosaicRedefinitionForkHeight) {
+			this.mosaicRedefinitionForkHeight = mosaicRedefinitionForkHeight;
+			return this;
+		}
+
+		/**
+		 * Sets the second fee fork height
+		 *
+		 * @return The fork configuration builder.
+		 */
+		public Builder secondFeeForkHeight(final BlockHeight secondFeeForkHeight) {
+			this.secondFeeForkHeight = secondFeeForkHeight;
+			return this;
+		}
+
+		/**
+		 * Builds the fork configuration.
+		 *
+		 * @return The fork configuration.
+		 */
+		public ForkConfiguration build() {
+			return new ForkConfiguration(this);
+		}
 	}
 }

--- a/nis/src/main/java/org/nem/nis/ForkConfiguration.java
+++ b/nis/src/main/java/org/nem/nis/ForkConfiguration.java
@@ -2,6 +2,7 @@ package org.nem.nis;
 
 import org.nem.core.crypto.Hash;
 import org.nem.core.model.NemProperties;
+import org.nem.core.model.NetworkInfo;
 import org.nem.core.model.NetworkInfos;
 import org.nem.core.model.primitive.BlockHeight;
 
@@ -135,16 +136,7 @@ public class ForkConfiguration {
 		 * Creates the default builder.
 		 */
 		public Builder() {
-			final int version = NetworkInfos.getDefault().getVersion() << 24;
-			treasuryReissuanceForkHeight = new BlockHeight(1);
-			treasuryReissuanceForkTransactionHashes = Collections.emptyList();
-			treasuryReissuanceForkFallbackTransactionHashes = Collections.emptyList();
-			multisigMOfNForkHeight = new BlockHeight(BlockMarkerConstants.MULTISIG_M_OF_N_FORK(version));
-			mosaicsForkHeight = new BlockHeight(BlockMarkerConstants.MOSAICS_FORK(version));
-			feeForkHeight = new BlockHeight(BlockMarkerConstants.FEE_FORK(version));
-			remoteAccountForkHeight = new BlockHeight(BlockMarkerConstants.REMOTE_ACCOUNT_FORK(version));
-			mosaicRedefinitionForkHeight = new BlockHeight(BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(version));
-			secondFeeForkHeight = new BlockHeight(BlockMarkerConstants.SECOND_FEE_FORK(version));
+			this(new NemProperties(new Properties()));
 		}
 
 		/**
@@ -153,7 +145,17 @@ public class ForkConfiguration {
 		 * @param properties nis properties.
 		 */
 		public Builder(final NemProperties properties) {
-			final int version = NetworkInfos.getDefault().getVersion() << 24;
+			this(properties, NetworkInfos.getDefault());
+		}
+
+		/**
+		 * Creates a builder for a fork configuration from nis configuration.
+		 *
+		 * @param properties nis properties.
+		 * @param networkInfo The network info.
+		 */
+		public Builder(final NemProperties properties, final NetworkInfo networkInfo) {
+			final int version = networkInfo.getVersion() << 24;
 			this.treasuryReissuanceForkHeight = new BlockHeight(properties.getOptionalInteger("nis.treasuryReissuanceForkHeight", 1));
 			this.treasuryReissuanceForkTransactionHashes = Collections
 					.unmodifiableList(parseHashes(properties, "nis.treasuryReissuanceForkTransactionHashes"));

--- a/nis/src/main/java/org/nem/nis/ForkConfiguration.java
+++ b/nis/src/main/java/org/nem/nis/ForkConfiguration.java
@@ -19,10 +19,9 @@ public class ForkConfiguration {
 
 	private final BlockHeight multisigMOfNForkHeight;
 	private final BlockHeight mosaicsForkHeight;
-	private final BlockHeight feeForkHeight;
 	private final BlockHeight remoteAccountForkHeight;
 	private final BlockHeight mosaicRedefinitionForkHeight;
-	private final BlockHeight secondFeeForkHeight;
+	private final FeeForkDto feeForkDto;
 
 	private ForkConfiguration(final Builder builder) {
 		this.treasuryReissuanceForkHeight = builder.treasuryReissuanceForkHeight;
@@ -30,10 +29,9 @@ public class ForkConfiguration {
 		this.treasuryReissuanceForkFallbackTransactionHashes = builder.treasuryReissuanceForkFallbackTransactionHashes;
 		this.multisigMOfNForkHeight = builder.multisigMOfNForkHeight;
 		this.mosaicsForkHeight = builder.mosaicsForkHeight;
-		this.feeForkHeight = builder.feeForkHeight;
 		this.remoteAccountForkHeight = builder.remoteAccountForkHeight;
 		this.mosaicRedefinitionForkHeight = builder.mosaicRedefinitionForkHeight;
-		this.secondFeeForkHeight = builder.secondFeeForkHeight;
+		this.feeForkDto = new FeeForkDto(builder.firstFeeForkHeight, builder.secondFeeForkHeight);
 	}
 
 	/**
@@ -68,7 +66,7 @@ public class ForkConfiguration {
 	 *
 	 * @return The height of the fork.
 	 */
-	public BlockHeight getmultisigMOfNForkHeight() {
+	public BlockHeight getMultisigMOfNForkHeight() {
 		return this.multisigMOfNForkHeight;
 	}
 
@@ -79,16 +77,6 @@ public class ForkConfiguration {
 	 */
 	public BlockHeight getMosaicsForkHeight() {
 		return this.mosaicsForkHeight;
-	}
-
-	/**
-	 * Gets the height of the fee fork.
-	 *
-	 * @return The height of the fork.
-	 */
-
-	public BlockHeight getFeeForkHeight() {
-		return this.feeForkHeight;
 	}
 
 	/**
@@ -110,12 +98,12 @@ public class ForkConfiguration {
 	}
 
 	/**
-	 * Gets the height of the second fee fork.
+	 * Gets the fee forks.
 	 *
-	 * @return The height of the fork.
+	 * @return The fee forks.
 	 */
-	public BlockHeight getSecondFeeForkHeight() {
-		return this.secondFeeForkHeight;
+	public FeeForkDto getFeeFork() {
+		return this.feeForkDto;
 	}
 
 	/**
@@ -127,7 +115,7 @@ public class ForkConfiguration {
 		private List<Hash> treasuryReissuanceForkFallbackTransactionHashes;
 		private BlockHeight multisigMOfNForkHeight;
 		private BlockHeight mosaicsForkHeight;
-		private BlockHeight feeForkHeight;
+		private BlockHeight firstFeeForkHeight;
 		private BlockHeight remoteAccountForkHeight;
 		private BlockHeight mosaicRedefinitionForkHeight;
 		private BlockHeight secondFeeForkHeight;
@@ -149,6 +137,15 @@ public class ForkConfiguration {
 		}
 
 		/**
+		 * Creates a builder for a fork configuration from network info.
+		 *
+		 * @param networkInfo The network info
+		 */
+		public Builder(final NetworkInfo networkInfo) {
+			this(new NemProperties(new Properties()), networkInfo);
+		}
+
+		/**
 		 * Creates a builder for a fork configuration from nis configuration.
 		 *
 		 * @param properties nis properties.
@@ -166,7 +163,8 @@ public class ForkConfiguration {
 					properties.getOptionalLong("nis.multisigMOfNForkHeight", BlockMarkerConstants.MULTISIG_M_OF_N_FORK(version)));
 			this.mosaicsForkHeight = new BlockHeight(
 					properties.getOptionalLong("nis.mosaicsForkHeight", BlockMarkerConstants.MOSAICS_FORK(version)));
-			this.feeForkHeight = new BlockHeight(properties.getOptionalLong("nis.feeForkHeight", BlockMarkerConstants.FEE_FORK(version)));
+			this.firstFeeForkHeight = new BlockHeight(
+					properties.getOptionalLong("nis.firstFeeForkHeight", BlockMarkerConstants.FEE_FORK(version)));
 			this.remoteAccountForkHeight = new BlockHeight(
 					properties.getOptionalLong("nis.remoteAccountForkHeight", BlockMarkerConstants.REMOTE_ACCOUNT_FORK(version)));
 			this.mosaicRedefinitionForkHeight = new BlockHeight(
@@ -235,8 +233,8 @@ public class ForkConfiguration {
 		 *
 		 * @return The fork configuration builder.
 		 */
-		public Builder feeForkHeight(final BlockHeight feeForkHeight) {
-			this.feeForkHeight = feeForkHeight;
+		public Builder firstFeeForkHeight(final BlockHeight firstFeeForkHeight) {
+			this.firstFeeForkHeight = firstFeeForkHeight;
 			return this;
 		}
 

--- a/nis/src/main/java/org/nem/nis/ForkConfiguration.java
+++ b/nis/src/main/java/org/nem/nis/ForkConfiguration.java
@@ -21,7 +21,7 @@ public class ForkConfiguration {
 	private final BlockHeight mosaicsForkHeight;
 	private final BlockHeight remoteAccountForkHeight;
 	private final BlockHeight mosaicRedefinitionForkHeight;
-	private final FeeForkDto feeForkDto;
+	private final FeeFork feeFork;
 
 	private ForkConfiguration(final Builder builder) {
 		this.treasuryReissuanceForkHeight = builder.treasuryReissuanceForkHeight;
@@ -31,7 +31,7 @@ public class ForkConfiguration {
 		this.mosaicsForkHeight = builder.mosaicsForkHeight;
 		this.remoteAccountForkHeight = builder.remoteAccountForkHeight;
 		this.mosaicRedefinitionForkHeight = builder.mosaicRedefinitionForkHeight;
-		this.feeForkDto = new FeeForkDto(builder.firstFeeForkHeight, builder.secondFeeForkHeight);
+		this.feeFork = new FeeFork(builder.firstFeeForkHeight, builder.secondFeeForkHeight);
 	}
 
 	/**
@@ -102,8 +102,8 @@ public class ForkConfiguration {
 	 *
 	 * @return The fee forks.
 	 */
-	public FeeForkDto getFeeFork() {
-		return this.feeForkDto;
+	public FeeFork getFeeFork() {
+		return this.feeFork;
 	}
 
 	/**

--- a/nis/src/main/java/org/nem/nis/ForkConfiguration.java
+++ b/nis/src/main/java/org/nem/nis/ForkConfiguration.java
@@ -160,18 +160,17 @@ public class ForkConfiguration {
 			this.treasuryReissuanceForkFallbackTransactionHashes = Collections
 					.unmodifiableList(parseHashes(properties, "nis.treasuryReissuanceForkFallbackTransactionHashes"));
 
-			this.multisigMOfNForkHeight = new BlockHeight(properties.getOptionalLong("nis.multisigMOfNForkHeight",
-					BlockMarkerConstants.MULTISIG_M_OF_N_FORK(version)));
-			this.mosaicsForkHeight = new BlockHeight(properties.getOptionalLong("nis.mosaicsForkHeight",
-					BlockMarkerConstants.MOSAICS_FORK(version)));
-			this.feeForkHeight = new BlockHeight(properties.getOptionalLong("nis.feeForkHeight",
-					BlockMarkerConstants.FEE_FORK(version)));
-			this.remoteAccountForkHeight = new BlockHeight(properties.getOptionalLong("nis.remoteAccountForkHeight",
-					BlockMarkerConstants.REMOTE_ACCOUNT_FORK(version)));
-			this.mosaicRedefinitionForkHeight = new BlockHeight(properties.getOptionalLong("nis.mosaicRedefinitionForkHeight",
-					BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(version)));
-			this.secondFeeForkHeight = new BlockHeight(properties.getOptionalLong("nis.secondFeeForkHeight",
-					BlockMarkerConstants.SECOND_FEE_FORK(version)));
+			this.multisigMOfNForkHeight = new BlockHeight(
+					properties.getOptionalLong("nis.multisigMOfNForkHeight", BlockMarkerConstants.MULTISIG_M_OF_N_FORK(version)));
+			this.mosaicsForkHeight = new BlockHeight(
+					properties.getOptionalLong("nis.mosaicsForkHeight", BlockMarkerConstants.MOSAICS_FORK(version)));
+			this.feeForkHeight = new BlockHeight(properties.getOptionalLong("nis.feeForkHeight", BlockMarkerConstants.FEE_FORK(version)));
+			this.remoteAccountForkHeight = new BlockHeight(
+					properties.getOptionalLong("nis.remoteAccountForkHeight", BlockMarkerConstants.REMOTE_ACCOUNT_FORK(version)));
+			this.mosaicRedefinitionForkHeight = new BlockHeight(
+					properties.getOptionalLong("nis.mosaicRedefinitionForkHeight", BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(version)));
+			this.secondFeeForkHeight = new BlockHeight(
+					properties.getOptionalLong("nis.secondFeeForkHeight", BlockMarkerConstants.SECOND_FEE_FORK(version)));
 		}
 
 		private static List<Hash> parseHashes(final NemProperties properties, final String propertyName) {
@@ -204,8 +203,7 @@ public class ForkConfiguration {
 		 *
 		 * @return The fork configuration builder.
 		 */
-		public Builder treasuryReissuanceForkFallbackTransactionHashes(
-				final List<Hash> treasuryReissuanceForkFallbackTransactionHashes) {
+		public Builder treasuryReissuanceForkFallbackTransactionHashes(final List<Hash> treasuryReissuanceForkFallbackTransactionHashes) {
 			this.treasuryReissuanceForkFallbackTransactionHashes = treasuryReissuanceForkFallbackTransactionHashes;
 			return this;
 		}

--- a/nis/src/main/java/org/nem/nis/NamespaceConstants.java
+++ b/nis/src/main/java/org/nem/nis/NamespaceConstants.java
@@ -1,6 +1,7 @@
 package org.nem.nis;
 
 import org.nem.core.model.mosaic.*;
+import org.nem.core.model.primitive.BlockHeight;
 import org.nem.core.model.primitive.Supply;
 import org.nem.nis.state.*;
 
@@ -14,17 +15,21 @@ public class NamespaceConstants {
 	/**
 	 * The namespace entry for 'nem' that contains a single mosaic 'nem.xem'.
 	 */
-	public static final NamespaceEntry NAMESPACE_ENTRY_NEM = new NamespaceEntry(MosaicConstants.NAMESPACE_NEM, createNemMosaics());
+	public static NamespaceEntry NAMESPACE_ENTRY_NEM;
 
-	private static Mosaics createNemMosaics() {
+	static {
+		setNamespaceEntry();
+	}
+
+	private static Mosaics createNemMosaics(final BlockHeight mosaicRedefinitionForkHeight) {
 		final MosaicEntry mosaicEntry = new MosaicEntry(MosaicConstants.MOSAIC_DEFINITION_XEM);
-		return new UnmodifiableMosaics(Collections.singletonList(mosaicEntry));
+		return new UnmodifiableMosaics(Collections.singletonList(mosaicEntry), mosaicRedefinitionForkHeight);
 	}
 
 	private static class UnmodifiableMosaics extends Mosaics {
 
-		public UnmodifiableMosaics(final Collection<MosaicEntry> mosaics) {
-			super(MosaicConstants.NAMESPACE_ID_NEM);
+		public UnmodifiableMosaics(final Collection<MosaicEntry> mosaics, final BlockHeight mosaicRedefinitionForkHeight) {
+			super(MosaicConstants.NAMESPACE_ID_NEM, mosaicRedefinitionForkHeight);
 			mosaics.forEach(entry -> super.add(new UnmodifiableMosaicEntry(entry)));
 		}
 
@@ -54,5 +59,19 @@ public class NamespaceConstants {
 		public void decreaseSupply(final Supply decrease) {
 			throw new UnsupportedOperationException("decreaseSupply is not allowed");
 		}
+	}
+
+	private static void setNamespaceEntry() {
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		setNamespaceEntry(forkConfiguration.getMosaicRedefinitionForkHeight());
+	}
+
+	/**
+	 * Sets the namespace entry for 'nem' that contains a single mosaic 'nem.xem'.
+	 *
+	 * @param mosaicRedefinitionForkHeight The mosaic redefinition fork height.
+	 */
+	public static void setNamespaceEntry(final BlockHeight mosaicRedefinitionForkHeight) {
+		NAMESPACE_ENTRY_NEM = new NamespaceEntry(MosaicConstants.NAMESPACE_NEM, createNemMosaics(mosaicRedefinitionForkHeight));
 	}
 }

--- a/nis/src/main/java/org/nem/nis/NemNamespaceEntry.java
+++ b/nis/src/main/java/org/nem/nis/NemNamespaceEntry.java
@@ -3,6 +3,7 @@ package org.nem.nis;
 import org.nem.core.model.mosaic.*;
 import org.nem.core.model.primitive.BlockHeight;
 import org.nem.core.model.primitive.Supply;
+import org.nem.core.utils.SetOnce;
 import org.nem.nis.state.*;
 
 import java.util.*;
@@ -15,7 +16,13 @@ public class NemNamespaceEntry {
 	/**
 	 * The namespace entry for 'nem' that contains a single mosaic 'nem.xem'.
 	 */
-	private static NamespaceEntry instance;
+	private static final SetOnce<NamespaceEntry> instance;
+
+	static {
+		final BlockHeight mosaicRedefinitionForkHeight = new ForkConfiguration.Builder().build().getMosaicRedefinitionForkHeight();
+
+		instance = new SetOnce<>(createNemNamespaceEntry(mosaicRedefinitionForkHeight));
+	}
 
 	private static Mosaics createNemMosaics(final BlockHeight mosaicRedefinitionForkHeight) {
 		final MosaicEntry mosaicEntry = new MosaicEntry(MosaicConstants.MOSAIC_DEFINITION_XEM);
@@ -57,17 +64,25 @@ public class NemNamespaceEntry {
 		}
 	}
 
+	private static NamespaceEntry createNemNamespaceEntry(final BlockHeight mosaicRedefinitionForkHeight) {
+		return new NamespaceEntry(MosaicConstants.NAMESPACE_NEM, createNemMosaics(mosaicRedefinitionForkHeight));
+	}
+
 	/**
 	 * Gets the namespace entry for 'nem' that contains a single mosaic 'nem.xem'.
 	 *
-	 * @param mosaicRedefinitionForkHeight The mosaic redefinition fork height.
 	 * @return The namespace entry.
 	 */
-	public static NamespaceEntry getInstance(final BlockHeight mosaicRedefinitionForkHeight) {
-		if (null == instance) {
-			instance = new NamespaceEntry(MosaicConstants.NAMESPACE_NEM, createNemMosaics(mosaicRedefinitionForkHeight));
-		}
+	public static NamespaceEntry getDefault() {
+		return instance.get();
+	}
 
-		return instance;
+	/**
+	 * Sets the namespace entry for 'nem' that contains a single mosaic 'nem.xem'.
+	 *
+	 * @param mosaicRedefinitionForkHeight The mosaic redefinition fork height.
+	 */
+	public static void setDefault(final BlockHeight mosaicRedefinitionForkHeight) {
+		instance.set(createNemNamespaceEntry(mosaicRedefinitionForkHeight));
 	}
 }

--- a/nis/src/main/java/org/nem/nis/NemNamespaceEntry.java
+++ b/nis/src/main/java/org/nem/nis/NemNamespaceEntry.java
@@ -65,8 +65,7 @@ public class NemNamespaceEntry {
 	 */
 	public static NamespaceEntry getInstance(final BlockHeight mosaicRedefinitionForkHeight) {
 		if (null == instance) {
-			instance = new NamespaceEntry(MosaicConstants.NAMESPACE_NEM,
-					createNemMosaics(mosaicRedefinitionForkHeight));
+			instance = new NamespaceEntry(MosaicConstants.NAMESPACE_NEM, createNemMosaics(mosaicRedefinitionForkHeight));
 		}
 
 		return instance;

--- a/nis/src/main/java/org/nem/nis/NemNamespaceEntry.java
+++ b/nis/src/main/java/org/nem/nis/NemNamespaceEntry.java
@@ -85,4 +85,11 @@ public class NemNamespaceEntry {
 	public static void setDefault(final BlockHeight mosaicRedefinitionForkHeight) {
 		instance.set(createNemNamespaceEntry(mosaicRedefinitionForkHeight));
 	}
+
+	/**
+	 * Resets the namespace entry for 'nem' to the default value.
+	 */
+	public static void resetToDefault() {
+		instance.set(null);
+	}
 }

--- a/nis/src/main/java/org/nem/nis/NemNamespaceEntry.java
+++ b/nis/src/main/java/org/nem/nis/NemNamespaceEntry.java
@@ -8,18 +8,14 @@ import org.nem.nis.state.*;
 import java.util.*;
 
 /**
- * Constants used by namespace related classes.
+ * Nem namespace related classes.
  */
-public class NamespaceConstants {
+public class NemNamespaceEntry {
 
 	/**
 	 * The namespace entry for 'nem' that contains a single mosaic 'nem.xem'.
 	 */
-	public static NamespaceEntry NAMESPACE_ENTRY_NEM;
-
-	static {
-		setNamespaceEntry();
-	}
+	private static NamespaceEntry instance;
 
 	private static Mosaics createNemMosaics(final BlockHeight mosaicRedefinitionForkHeight) {
 		final MosaicEntry mosaicEntry = new MosaicEntry(MosaicConstants.MOSAIC_DEFINITION_XEM);
@@ -61,17 +57,18 @@ public class NamespaceConstants {
 		}
 	}
 
-	private static void setNamespaceEntry() {
-		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
-		setNamespaceEntry(forkConfiguration.getMosaicRedefinitionForkHeight());
-	}
-
 	/**
-	 * Sets the namespace entry for 'nem' that contains a single mosaic 'nem.xem'.
+	 * Gets the namespace entry for 'nem' that contains a single mosaic 'nem.xem'.
 	 *
 	 * @param mosaicRedefinitionForkHeight The mosaic redefinition fork height.
+	 * @return The namespace entry.
 	 */
-	public static void setNamespaceEntry(final BlockHeight mosaicRedefinitionForkHeight) {
-		NAMESPACE_ENTRY_NEM = new NamespaceEntry(MosaicConstants.NAMESPACE_NEM, createNemMosaics(mosaicRedefinitionForkHeight));
+	public static NamespaceEntry getInstance(final BlockHeight mosaicRedefinitionForkHeight) {
+		if (null == instance) {
+			instance = new NamespaceEntry(MosaicConstants.NAMESPACE_NEM,
+					createNemMosaics(mosaicRedefinitionForkHeight));
+		}
+
+		return instance;
 	}
 }

--- a/nis/src/main/java/org/nem/nis/cache/DefaultNamespaceCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/DefaultNamespaceCache.java
@@ -21,7 +21,7 @@ public class DefaultNamespaceCache implements ExtendedNamespaceCache<DefaultName
 	/**
 	 * Creates a new namespace cache.
 	 *
-	 * @param mosaicRedefinitionForkHeight The height at which mosaic redefinition fork.
+	 * @param mosaicRedefinitionForkHeight The height of mosaic redefinition fork.
 	 */
 	public DefaultNamespaceCache(final BlockHeight mosaicRedefinitionForkHeight) {
 		this(100, mosaicRedefinitionForkHeight);

--- a/nis/src/main/java/org/nem/nis/cache/DefaultNamespaceCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/DefaultNamespaceCache.java
@@ -3,7 +3,7 @@ package org.nem.nis.cache;
 import org.nem.core.model.mosaic.MosaicConstants;
 import org.nem.core.model.namespace.*;
 import org.nem.core.model.primitive.BlockHeight;
-import org.nem.nis.NamespaceConstants;
+import org.nem.nis.NemNamespaceEntry;
 import org.nem.nis.cache.delta.*;
 import org.nem.nis.state.*;
 
@@ -58,7 +58,7 @@ public class DefaultNamespaceCache implements ExtendedNamespaceCache<DefaultName
 
 	public NamespaceEntry get(final NamespaceId id) {
 		if (id.equals(MosaicConstants.NAMESPACE_ID_NEM)) {
-			return NamespaceConstants.NAMESPACE_ENTRY_NEM;
+			return NemNamespaceEntry.getInstance(this.mosaicRedefinitionForkHeight);
 		}
 
 		final RootNamespaceHistory history = this.getHistory(id);

--- a/nis/src/main/java/org/nem/nis/cache/DefaultNamespaceCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/DefaultNamespaceCache.java
@@ -31,7 +31,8 @@ public class DefaultNamespaceCache implements ExtendedNamespaceCache<DefaultName
 		this(new MutableObjectAwareDeltaMap<>(size), mosaicRedefinitionForkHeight);
 	}
 
-	private DefaultNamespaceCache(final MutableObjectAwareDeltaMap<NamespaceId, RootNamespaceHistory> rootMap, final BlockHeight mosaicRedefinitionForkHeight) {
+	private DefaultNamespaceCache(final MutableObjectAwareDeltaMap<NamespaceId, RootNamespaceHistory> rootMap,
+			final BlockHeight mosaicRedefinitionForkHeight) {
 		this.rootMap = rootMap;
 		this.mosaicRedefinitionForkHeight = mosaicRedefinitionForkHeight;
 	}
@@ -252,7 +253,8 @@ public class DefaultNamespaceCache implements ExtendedNamespaceCache<DefaultName
 			this.mosaicRedefinitionForkHeight = mosaicRedefinitionForkHeight;
 		}
 
-		public RootNamespace(final Namespace root, final Mosaics rootMosaics, final Collection<ChildNamespace> children, final BlockHeight mosaicRedefinitionForkHeight) {
+		public RootNamespace(final Namespace root, final Mosaics rootMosaics, final Collection<ChildNamespace> children,
+				final BlockHeight mosaicRedefinitionForkHeight) {
 			this.root = new NamespaceEntry(root, rootMosaics);
 			this.children = new HashMap<>(children.stream().collect(Collectors.toMap(cn -> cn.id, cn -> cn)));
 			this.mosaicRedefinitionForkHeight = mosaicRedefinitionForkHeight;

--- a/nis/src/main/java/org/nem/nis/cache/DefaultNamespaceCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/DefaultNamespaceCache.java
@@ -58,7 +58,7 @@ public class DefaultNamespaceCache implements ExtendedNamespaceCache<DefaultName
 
 	public NamespaceEntry get(final NamespaceId id) {
 		if (id.equals(MosaicConstants.NAMESPACE_ID_NEM)) {
-			return NemNamespaceEntry.getInstance(this.mosaicRedefinitionForkHeight);
+			return NemNamespaceEntry.getDefault();
 		}
 
 		final RootNamespaceHistory history = this.getHistory(id);

--- a/nis/src/main/java/org/nem/nis/secret/BlockTransactionObserverFactory.java
+++ b/nis/src/main/java/org/nem/nis/secret/BlockTransactionObserverFactory.java
@@ -1,5 +1,6 @@
 package org.nem.nis.secret;
 
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.secret.pruning.*;
 
@@ -12,21 +13,25 @@ public class BlockTransactionObserverFactory {
 	private static final int DEFAULT_ESTIMATED_BLOCKS_PER_YEAR = 60 * 24 * 365;
 	private final EnumSet<ObserverOption> observerOptions;
 	private final int estimatedBlocksPerYear;
+	private final ForkConfiguration forkConfiguration;
 
 	/**
 	 * Creates a new transaction observer factory with no additional options.
+	 *
+	 * @param forkConfiguration The fork configuration.
 	 */
-	public BlockTransactionObserverFactory() {
-		this(EnumSet.noneOf(ObserverOption.class), DEFAULT_ESTIMATED_BLOCKS_PER_YEAR);
+	public BlockTransactionObserverFactory(final ForkConfiguration forkConfiguration) {
+		this(EnumSet.noneOf(ObserverOption.class), DEFAULT_ESTIMATED_BLOCKS_PER_YEAR, forkConfiguration);
 	}
 
 	/**
 	 * Creates a new transaction observer factory which uses additional options.
 	 *
 	 * @param observerOptions The observer options.
+	 * @param forkConfiguration The fork configuration.
 	 */
-	public BlockTransactionObserverFactory(final EnumSet<ObserverOption> observerOptions) {
-		this(observerOptions, DEFAULT_ESTIMATED_BLOCKS_PER_YEAR);
+	public BlockTransactionObserverFactory(final EnumSet<ObserverOption> observerOptions, final ForkConfiguration forkConfiguration) {
+		this(observerOptions, DEFAULT_ESTIMATED_BLOCKS_PER_YEAR, forkConfiguration);
 	}
 
 	/**
@@ -34,10 +39,12 @@ public class BlockTransactionObserverFactory {
 	 *
 	 * @param observerOptions The observer options.
 	 * @param estimatedBlocksPerYear The estimated number of blocks per year.
+	 * @param forkConfiguration The fork configuration.
 	 */
-	public BlockTransactionObserverFactory(final EnumSet<ObserverOption> observerOptions, final int estimatedBlocksPerYear) {
+	public BlockTransactionObserverFactory(final EnumSet<ObserverOption> observerOptions, final int estimatedBlocksPerYear, final ForkConfiguration forkConfiguration) {
 		this.observerOptions = observerOptions;
 		this.estimatedBlocksPerYear = estimatedBlocksPerYear;
+		this.forkConfiguration = forkConfiguration;
 	}
 
 	/**
@@ -67,7 +74,7 @@ public class BlockTransactionObserverFactory {
 		builder.add(new AccountsHeightObserver(nisCache));
 		builder.add(new BalanceCommitTransferObserver(accountStateCache));
 		builder.add(new HarvestRewardCommitObserver(accountStateCache));
-		builder.add(new RemoteObserver(accountStateCache));
+		builder.add(new RemoteObserver(accountStateCache, this.forkConfiguration.getMosaicRedefinitionForkHeight()));
 		builder.add(new MultisigCosignatoryModificationObserver(accountStateCache));
 		builder.add(new MultisigMinCosignatoriesModificationObserver(accountStateCache));
 		builder.add(new TransactionHashesObserver(nisCache.getTransactionHashCache()));

--- a/nis/src/main/java/org/nem/nis/secret/BlockTransactionObserverFactory.java
+++ b/nis/src/main/java/org/nem/nis/secret/BlockTransactionObserverFactory.java
@@ -41,7 +41,8 @@ public class BlockTransactionObserverFactory {
 	 * @param estimatedBlocksPerYear The estimated number of blocks per year.
 	 * @param forkConfiguration The fork configuration.
 	 */
-	public BlockTransactionObserverFactory(final EnumSet<ObserverOption> observerOptions, final int estimatedBlocksPerYear, final ForkConfiguration forkConfiguration) {
+	public BlockTransactionObserverFactory(final EnumSet<ObserverOption> observerOptions, final int estimatedBlocksPerYear,
+			final ForkConfiguration forkConfiguration) {
 		this.observerOptions = observerOptions;
 		this.estimatedBlocksPerYear = estimatedBlocksPerYear;
 		this.forkConfiguration = forkConfiguration;

--- a/nis/src/main/java/org/nem/nis/secret/RemoteObserver.java
+++ b/nis/src/main/java/org/nem/nis/secret/RemoteObserver.java
@@ -45,8 +45,7 @@ public class RemoteObserver implements BlockTransactionObserver {
 	private void notify(final ImportanceTransferNotification notification, final BlockNotificationContext context) {
 		final Address remoteAddress = ImportanceTransferMode.Activate == notification.getMode()
 				? notification.getLessee().getAddress()
-				:
-				context.getHeight().getRaw() < this.mosaicRedefinitionForkHeight.getRaw()
+				: context.getHeight().getRaw() < this.mosaicRedefinitionForkHeight.getRaw()
 						? notification.getLessee().getAddress()
 						: this.getRemoteLinks(notification.getLessor()).getCurrent().getLinkedAddress();
 

--- a/nis/src/main/java/org/nem/nis/secret/RemoteObserver.java
+++ b/nis/src/main/java/org/nem/nis/secret/RemoteObserver.java
@@ -2,6 +2,7 @@ package org.nem.nis.secret;
 
 import org.nem.core.model.*;
 import org.nem.core.model.observers.*;
+import org.nem.core.model.primitive.BlockHeight;
 import org.nem.nis.BlockMarkerConstants;
 import org.nem.nis.cache.AccountStateCache;
 import org.nem.nis.state.*;
@@ -11,14 +12,17 @@ import org.nem.nis.state.*;
  */
 public class RemoteObserver implements BlockTransactionObserver {
 	private final AccountStateCache accountStateCache;
+	private final BlockHeight mosaicRedefinitionForkHeight;
 
 	/**
 	 * Creates a new observer.
 	 *
 	 * @param accountStateCache The account state cache.
+	 * @param mosaicRedefinitionForkHeight The mosaic redefinition fork height.
 	 */
-	public RemoteObserver(final AccountStateCache accountStateCache) {
+	public RemoteObserver(final AccountStateCache accountStateCache, final BlockHeight mosaicRedefinitionForkHeight) {
 		this.accountStateCache = accountStateCache;
+		this.mosaicRedefinitionForkHeight = mosaicRedefinitionForkHeight;
 	}
 
 	private RemoteLinks getRemoteLinks(final Address address) {
@@ -41,7 +45,8 @@ public class RemoteObserver implements BlockTransactionObserver {
 	private void notify(final ImportanceTransferNotification notification, final BlockNotificationContext context) {
 		final Address remoteAddress = ImportanceTransferMode.Activate == notification.getMode()
 				? notification.getLessee().getAddress()
-				: context.getHeight().getRaw() < BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(NetworkInfos.getDefault().getVersion() << 24)
+				:
+				context.getHeight().getRaw() < this.mosaicRedefinitionForkHeight.getRaw()
 						? notification.getLessee().getAddress()
 						: this.getRemoteLinks(notification.getLessor()).getCurrent().getLinkedAddress();
 

--- a/nis/src/main/java/org/nem/nis/state/Mosaics.java
+++ b/nis/src/main/java/org/nem/nis/state/Mosaics.java
@@ -16,14 +16,17 @@ import java.util.stream.Collectors;
 public class Mosaics implements ReadOnlyMosaics {
 	private final NamespaceId namespaceId;
 	private final ConcurrentHashMap<MosaicId, MosaicEntryHistory> hashMap = new ConcurrentHashMap<>();
+	private final BlockHeight mosaicRedefinitionForkHeight;
 
 	/**
 	 * Creates a new mosaics container.
 	 *
 	 * @param namespaceId The namespace id of all mosaics in the container.
+	 * @param mosaicRedefinitionForkHeight The mosaic redefinition fork height.
 	 */
-	public Mosaics(final NamespaceId namespaceId) {
+	public Mosaics(final NamespaceId namespaceId, final BlockHeight mosaicRedefinitionForkHeight) {
 		this.namespaceId = namespaceId;
+		this.mosaicRedefinitionForkHeight = mosaicRedefinitionForkHeight;
 	}
 
 	@Override
@@ -114,7 +117,7 @@ public class Mosaics implements ReadOnlyMosaics {
 		}
 
 		final MosaicEntryHistory history = this.hashMap.get(mosaicDefinition.getId());
-		if (height.getRaw() < BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(NetworkInfos.getDefault().getVersion() << 24)) {
+		if (height.getRaw() < this.mosaicRedefinitionForkHeight.getRaw()) {
 			history.push(entry);
 			return;
 		}
@@ -159,7 +162,7 @@ public class Mosaics implements ReadOnlyMosaics {
 	 */
 	public Mosaics copy() {
 		// note that mosaic ids are immutable
-		final Mosaics copy = new Mosaics(this.namespaceId);
+		final Mosaics copy = new Mosaics(this.namespaceId, this.mosaicRedefinitionForkHeight);
 		copy.hashMap.putAll(this.hashMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().copy())));
 		return copy;
 	}

--- a/nis/src/main/java/org/nem/nis/validators/TransactionValidatorFactory.java
+++ b/nis/src/main/java/org/nem/nis/validators/TransactionValidatorFactory.java
@@ -68,20 +68,23 @@ public class TransactionValidatorFactory {
 		final AggregateSingleTransactionValidatorBuilder builder = new AggregateSingleTransactionValidatorBuilder();
 
 		builder.add(new DeadlineValidator());
-		builder.add(new MinimumFeeValidator(this.networkInfo, nisCache.getNamespaceCache(), ignoreFees));
-		builder.add(new VersionTransactionValidator());
+		builder.add(new MinimumFeeValidator(this.networkInfo, nisCache.getNamespaceCache(), ignoreFees,
+				forkConfiguration.getFeeForkHeight(), forkConfiguration.getSecondFeeForkHeight()));
+		builder.add(new VersionTransactionValidator(this.forkConfiguration.getMosaicsForkHeight(), this.forkConfiguration.getmultisigMOfNForkHeight()));
 		builder.add(new TransactionNonFutureEntityValidator(this.timeProvider));
 		builder.add(new NemesisSinkValidator(this.forkConfiguration.getTreasuryReissuanceForkHeight()));
 		builder.add(new BalanceValidator());
 		builder.add(new TransactionNetworkValidator());
 
-		builder.add(new RemoteNonOperationalValidator(accountStateCache));
+		builder.add(new RemoteNonOperationalValidator(accountStateCache, this.forkConfiguration.getMosaicRedefinitionForkHeight()));
 		builder.add(new MultisigNonOperationalValidator(this.forkConfiguration, accountStateCache));
 
-		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.TRANSFER, new TransferTransactionValidator()));
+		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.TRANSFER,
+				new TransferTransactionValidator(this.forkConfiguration.getRemoteAccountForkHeight(), this.forkConfiguration.getmultisigMOfNForkHeight())));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.IMPORTANCE_TRANSFER,
-				new ImportanceTransferTransactionValidator(accountStateCache, namespaceCache)));
+				new ImportanceTransferTransactionValidator(accountStateCache, namespaceCache,
+						this.forkConfiguration.getRemoteAccountForkHeight())));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MULTISIG,
 				new MultisigTransactionSignerValidator(accountStateCache)));
@@ -89,15 +92,17 @@ public class TransactionValidatorFactory {
 				new FeeSinkNonOperationalValidator(this.forkConfiguration)));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MULTISIG_AGGREGATE_MODIFICATION,
-				new MultisigCosignatoryModificationValidator(accountStateCache)));
+				new MultisigCosignatoryModificationValidator(accountStateCache, this.forkConfiguration.getmultisigMOfNForkHeight())));
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MULTISIG_AGGREGATE_MODIFICATION,
 				new NumCosignatoryRangeValidator(accountStateCache)));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.PROVISION_NAMESPACE,
-				new ProvisionNamespaceTransactionValidator(namespaceCache)));
+				new ProvisionNamespaceTransactionValidator(namespaceCache, this.forkConfiguration.getFeeForkHeight(),
+						this.forkConfiguration.getSecondFeeForkHeight())));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MOSAIC_DEFINITION_CREATION,
-				new MosaicDefinitionCreationTransactionValidator(namespaceCache)));
+				new MosaicDefinitionCreationTransactionValidator(namespaceCache, this.forkConfiguration.getFeeForkHeight(),
+						this.forkConfiguration.getSecondFeeForkHeight())));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MOSAIC_SUPPLY_CHANGE,
 				new MosaicSupplyChangeTransactionValidator(namespaceCache)));

--- a/nis/src/main/java/org/nem/nis/validators/TransactionValidatorFactory.java
+++ b/nis/src/main/java/org/nem/nis/validators/TransactionValidatorFactory.java
@@ -70,7 +70,8 @@ public class TransactionValidatorFactory {
 		builder.add(new DeadlineValidator());
 		builder.add(new MinimumFeeValidator(this.networkInfo, nisCache.getNamespaceCache(), ignoreFees,
 				forkConfiguration.getFeeForkHeight(), forkConfiguration.getSecondFeeForkHeight()));
-		builder.add(new VersionTransactionValidator(this.forkConfiguration.getMosaicsForkHeight(), this.forkConfiguration.getmultisigMOfNForkHeight()));
+		builder.add(new VersionTransactionValidator(this.forkConfiguration.getMosaicsForkHeight(),
+				this.forkConfiguration.getmultisigMOfNForkHeight()));
 		builder.add(new TransactionNonFutureEntityValidator(this.timeProvider));
 		builder.add(new NemesisSinkValidator(this.forkConfiguration.getTreasuryReissuanceForkHeight()));
 		builder.add(new BalanceValidator());
@@ -79,12 +80,12 @@ public class TransactionValidatorFactory {
 		builder.add(new RemoteNonOperationalValidator(accountStateCache, this.forkConfiguration.getMosaicRedefinitionForkHeight()));
 		builder.add(new MultisigNonOperationalValidator(this.forkConfiguration, accountStateCache));
 
-		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.TRANSFER,
-				new TransferTransactionValidator(this.forkConfiguration.getRemoteAccountForkHeight(), this.forkConfiguration.getmultisigMOfNForkHeight())));
+		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.TRANSFER, new TransferTransactionValidator(
+				this.forkConfiguration.getRemoteAccountForkHeight(), this.forkConfiguration.getmultisigMOfNForkHeight())));
 
-		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.IMPORTANCE_TRANSFER,
-				new ImportanceTransferTransactionValidator(accountStateCache, namespaceCache,
-						this.forkConfiguration.getRemoteAccountForkHeight())));
+		builder.add(
+				new TSingleTransactionValidatorAdapter<>(TransactionTypes.IMPORTANCE_TRANSFER, new ImportanceTransferTransactionValidator(
+						accountStateCache, namespaceCache, this.forkConfiguration.getRemoteAccountForkHeight())));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MULTISIG,
 				new MultisigTransactionSignerValidator(accountStateCache)));
@@ -96,9 +97,9 @@ public class TransactionValidatorFactory {
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MULTISIG_AGGREGATE_MODIFICATION,
 				new NumCosignatoryRangeValidator(accountStateCache)));
 
-		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.PROVISION_NAMESPACE,
-				new ProvisionNamespaceTransactionValidator(namespaceCache, this.forkConfiguration.getFeeForkHeight(),
-						this.forkConfiguration.getSecondFeeForkHeight())));
+		builder.add(
+				new TSingleTransactionValidatorAdapter<>(TransactionTypes.PROVISION_NAMESPACE, new ProvisionNamespaceTransactionValidator(
+						namespaceCache, this.forkConfiguration.getFeeForkHeight(), this.forkConfiguration.getSecondFeeForkHeight())));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MOSAIC_DEFINITION_CREATION,
 				new MosaicDefinitionCreationTransactionValidator(namespaceCache, this.forkConfiguration.getFeeForkHeight(),

--- a/nis/src/main/java/org/nem/nis/validators/TransactionValidatorFactory.java
+++ b/nis/src/main/java/org/nem/nis/validators/TransactionValidatorFactory.java
@@ -3,9 +3,9 @@ package org.nem.nis.validators;
 import org.nem.core.model.*;
 import org.nem.core.time.TimeProvider;
 import org.nem.nis.cache.*;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.validators.transaction.*;
 import org.nem.nis.validators.unconfirmed.*;
-import org.nem.nis.ForkConfiguration;
 
 /**
  * Factory for creating TransactionValidator objects.
@@ -68,10 +68,10 @@ public class TransactionValidatorFactory {
 		final AggregateSingleTransactionValidatorBuilder builder = new AggregateSingleTransactionValidatorBuilder();
 
 		builder.add(new DeadlineValidator());
-		builder.add(new MinimumFeeValidator(this.networkInfo, nisCache.getNamespaceCache(), ignoreFees,
-				forkConfiguration.getFeeForkHeight(), forkConfiguration.getSecondFeeForkHeight()));
+		builder.add(
+				new MinimumFeeValidator(this.networkInfo, nisCache.getNamespaceCache(), ignoreFees, this.forkConfiguration.getFeeFork()));
 		builder.add(new VersionTransactionValidator(this.forkConfiguration.getMosaicsForkHeight(),
-				this.forkConfiguration.getmultisigMOfNForkHeight()));
+				this.forkConfiguration.getMultisigMOfNForkHeight()));
 		builder.add(new TransactionNonFutureEntityValidator(this.timeProvider));
 		builder.add(new NemesisSinkValidator(this.forkConfiguration.getTreasuryReissuanceForkHeight()));
 		builder.add(new BalanceValidator());
@@ -81,7 +81,7 @@ public class TransactionValidatorFactory {
 		builder.add(new MultisigNonOperationalValidator(this.forkConfiguration, accountStateCache));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.TRANSFER, new TransferTransactionValidator(
-				this.forkConfiguration.getRemoteAccountForkHeight(), this.forkConfiguration.getmultisigMOfNForkHeight())));
+				this.forkConfiguration.getRemoteAccountForkHeight(), this.forkConfiguration.getMultisigMOfNForkHeight())));
 
 		builder.add(
 				new TSingleTransactionValidatorAdapter<>(TransactionTypes.IMPORTANCE_TRANSFER, new ImportanceTransferTransactionValidator(
@@ -93,17 +93,15 @@ public class TransactionValidatorFactory {
 				new FeeSinkNonOperationalValidator(this.forkConfiguration)));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MULTISIG_AGGREGATE_MODIFICATION,
-				new MultisigCosignatoryModificationValidator(accountStateCache, this.forkConfiguration.getmultisigMOfNForkHeight())));
+				new MultisigCosignatoryModificationValidator(accountStateCache, this.forkConfiguration.getMultisigMOfNForkHeight())));
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MULTISIG_AGGREGATE_MODIFICATION,
 				new NumCosignatoryRangeValidator(accountStateCache)));
 
-		builder.add(
-				new TSingleTransactionValidatorAdapter<>(TransactionTypes.PROVISION_NAMESPACE, new ProvisionNamespaceTransactionValidator(
-						namespaceCache, this.forkConfiguration.getFeeForkHeight(), this.forkConfiguration.getSecondFeeForkHeight())));
+		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.PROVISION_NAMESPACE,
+				new ProvisionNamespaceTransactionValidator(namespaceCache, this.forkConfiguration.getFeeFork())));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MOSAIC_DEFINITION_CREATION,
-				new MosaicDefinitionCreationTransactionValidator(namespaceCache, this.forkConfiguration.getFeeForkHeight(),
-						this.forkConfiguration.getSecondFeeForkHeight())));
+				new MosaicDefinitionCreationTransactionValidator(namespaceCache, this.forkConfiguration.getFeeFork())));
 
 		builder.add(new TSingleTransactionValidatorAdapter<>(TransactionTypes.MOSAIC_SUPPLY_CHANGE,
 				new MosaicSupplyChangeTransactionValidator(namespaceCache)));

--- a/nis/src/main/java/org/nem/nis/validators/transaction/ImportanceTransferTransactionValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/ImportanceTransferTransactionValidator.java
@@ -13,17 +13,20 @@ import org.nem.nis.validators.ValidationContext;
 public class ImportanceTransferTransactionValidator implements TSingleTransactionValidator<ImportanceTransferTransaction> {
 	private final ReadOnlyAccountStateCache accountStateCache;
 	private final ReadOnlyNamespaceCache namespaceCache;
+	private final BlockHeight remoteAccountForkHeight;
 
 	/**
 	 * Creates a new validator.
 	 *
 	 * @param accountStateCache The account state cache.
 	 * @param namespaceCache The namespace cache.
+	 * @param remoteAccountForkHeight The remote account fork height.
 	 */
 	public ImportanceTransferTransactionValidator(final ReadOnlyAccountStateCache accountStateCache,
-			final ReadOnlyNamespaceCache namespaceCache) {
+			final ReadOnlyNamespaceCache namespaceCache, final BlockHeight remoteAccountForkHeight) {
 		this.accountStateCache = accountStateCache;
 		this.namespaceCache = namespaceCache;
+		this.remoteAccountForkHeight = remoteAccountForkHeight;
 	}
 
 	@Override
@@ -84,7 +87,7 @@ public class ImportanceTransferTransactionValidator implements TSingleTransactio
 				// - does not own any namespace
 				// - is not a multisig account
 				// - is not a cosignatory of any multsig account
-				if (height.getRaw() >= BlockMarkerConstants.REMOTE_ACCOUNT_FORK(transaction.getVersion())) {
+				if (height.getRaw() >= this.remoteAccountForkHeight.getRaw()) {
 					if (!remoteAccountInfo.getMosaicIds().isEmpty()) {
 						return ValidationResult.FAILURE_DESTINATION_ACCOUNT_IN_USE;
 					}

--- a/nis/src/main/java/org/nem/nis/validators/transaction/MinimumFeeValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/MinimumFeeValidator.java
@@ -5,7 +5,7 @@ import org.nem.core.crypto.*;
 import org.nem.core.model.*;
 import org.nem.core.model.primitive.BlockHeight;
 import org.nem.nis.BlockMarkerConstants;
-import org.nem.nis.ForkConfiguration;
+import org.nem.nis.FeeForkDto;
 import org.nem.nis.cache.*;
 import org.nem.nis.validators.*;
 
@@ -19,8 +19,7 @@ public class MinimumFeeValidator implements SingleTransactionValidator {
 	private final NetworkInfo networkInfo;
 	private final ReadOnlyNamespaceCache namespaceCache;
 	private final boolean ignoreFees;
-	private final BlockHeight feeForkHeight;
-	private final BlockHeight secondFeeForkHeight;
+	private final FeeForkDto feeForkDto;
 
 	/**
 	 * Creates a validator.
@@ -28,16 +27,14 @@ public class MinimumFeeValidator implements SingleTransactionValidator {
 	 * @param networkInfo The network info.
 	 * @param namespaceCache The namespace cache.
 	 * @param ignoreFees Flag indicating if transaction fees should be ignored.
-	 * @param feeForkHeight The fee fork height.
-	 * @param secondFeeForkHeight The second fee fork height.
+	 * @param feeForkDto The fee fork heights.
 	 */
 	public MinimumFeeValidator(final NetworkInfo networkInfo, final ReadOnlyNamespaceCache namespaceCache, final boolean ignoreFees,
-			final BlockHeight feeForkHeight, final BlockHeight secondFeeForkHeight) {
+			final FeeForkDto feeForkDto) {
 		this.networkInfo = networkInfo;
 		this.namespaceCache = namespaceCache;
 		this.ignoreFees = ignoreFees;
-		this.feeForkHeight = feeForkHeight;
-		this.secondFeeForkHeight = secondFeeForkHeight;
+		this.feeForkDto = feeForkDto;
 	}
 
 	@Override
@@ -55,7 +52,7 @@ public class MinimumFeeValidator implements SingleTransactionValidator {
 		final NamespaceCacheLookupAdapters adapters = new NamespaceCacheLookupAdapters(this.namespaceCache);
 		final TransactionFeeCalculator calculator = new DefaultTransactionFeeCalculator(adapters.asMosaicFeeInformationLookup(),
 				context::getBlockHeight, new BlockHeight[]{
-						this.feeForkHeight, this.secondFeeForkHeight
+						this.feeForkDto.getFirstHeight(), this.feeForkDto.getSecondHeight()
 				});
 		return calculator.isFeeValid(transaction, context.getBlockHeight())
 				? ValidationResult.SUCCESS

--- a/nis/src/main/java/org/nem/nis/validators/transaction/MinimumFeeValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/MinimumFeeValidator.java
@@ -5,6 +5,7 @@ import org.nem.core.crypto.*;
 import org.nem.core.model.*;
 import org.nem.core.model.primitive.BlockHeight;
 import org.nem.nis.BlockMarkerConstants;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.validators.*;
 
@@ -18,6 +19,8 @@ public class MinimumFeeValidator implements SingleTransactionValidator {
 	private final NetworkInfo networkInfo;
 	private final ReadOnlyNamespaceCache namespaceCache;
 	private final boolean ignoreFees;
+	private final BlockHeight feeForkHeight;
+	private final BlockHeight secondFeeForkHeight;
 
 	/**
 	 * Creates a validator.
@@ -25,11 +28,16 @@ public class MinimumFeeValidator implements SingleTransactionValidator {
 	 * @param networkInfo The network info.
 	 * @param namespaceCache The namespace cache.
 	 * @param ignoreFees Flag indicating if transaction fees should be ignored.
+	 * @param feeForkHeight The fee fork height.
+	 * @param secondFeeForkHeight The second fee fork height.
 	 */
-	public MinimumFeeValidator(final NetworkInfo networkInfo, final ReadOnlyNamespaceCache namespaceCache, final boolean ignoreFees) {
+	public MinimumFeeValidator(final NetworkInfo networkInfo, final ReadOnlyNamespaceCache namespaceCache, final boolean ignoreFees,
+							   final BlockHeight feeForkHeight, final BlockHeight secondFeeForkHeight) {
 		this.networkInfo = networkInfo;
 		this.namespaceCache = namespaceCache;
 		this.ignoreFees = ignoreFees;
+		this.feeForkHeight = feeForkHeight;
+		this.secondFeeForkHeight = secondFeeForkHeight;
 	}
 
 	@Override
@@ -47,8 +55,8 @@ public class MinimumFeeValidator implements SingleTransactionValidator {
 		final NamespaceCacheLookupAdapters adapters = new NamespaceCacheLookupAdapters(this.namespaceCache);
 		final TransactionFeeCalculator calculator = new DefaultTransactionFeeCalculator(adapters.asMosaicFeeInformationLookup(),
 				context::getBlockHeight, new BlockHeight[]{
-						new BlockHeight(BlockMarkerConstants.FEE_FORK(transaction.getVersion())),
-						new BlockHeight(BlockMarkerConstants.SECOND_FEE_FORK(transaction.getVersion()))
+						this.feeForkHeight,
+						this.secondFeeForkHeight
 				});
 		return calculator.isFeeValid(transaction, context.getBlockHeight())
 				? ValidationResult.SUCCESS

--- a/nis/src/main/java/org/nem/nis/validators/transaction/MinimumFeeValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/MinimumFeeValidator.java
@@ -5,7 +5,7 @@ import org.nem.core.crypto.*;
 import org.nem.core.model.*;
 import org.nem.core.model.primitive.BlockHeight;
 import org.nem.nis.BlockMarkerConstants;
-import org.nem.nis.FeeForkDto;
+import org.nem.nis.FeeFork;
 import org.nem.nis.cache.*;
 import org.nem.nis.validators.*;
 
@@ -19,7 +19,7 @@ public class MinimumFeeValidator implements SingleTransactionValidator {
 	private final NetworkInfo networkInfo;
 	private final ReadOnlyNamespaceCache namespaceCache;
 	private final boolean ignoreFees;
-	private final FeeForkDto feeForkDto;
+	private final FeeFork feeFork;
 
 	/**
 	 * Creates a validator.
@@ -27,14 +27,14 @@ public class MinimumFeeValidator implements SingleTransactionValidator {
 	 * @param networkInfo The network info.
 	 * @param namespaceCache The namespace cache.
 	 * @param ignoreFees Flag indicating if transaction fees should be ignored.
-	 * @param feeForkDto The fee fork heights.
+	 * @param feeFork The fee fork heights.
 	 */
 	public MinimumFeeValidator(final NetworkInfo networkInfo, final ReadOnlyNamespaceCache namespaceCache, final boolean ignoreFees,
-			final FeeForkDto feeForkDto) {
+			final FeeFork feeFork) {
 		this.networkInfo = networkInfo;
 		this.namespaceCache = namespaceCache;
 		this.ignoreFees = ignoreFees;
-		this.feeForkDto = feeForkDto;
+		this.feeFork = feeFork;
 	}
 
 	@Override
@@ -52,7 +52,7 @@ public class MinimumFeeValidator implements SingleTransactionValidator {
 		final NamespaceCacheLookupAdapters adapters = new NamespaceCacheLookupAdapters(this.namespaceCache);
 		final TransactionFeeCalculator calculator = new DefaultTransactionFeeCalculator(adapters.asMosaicFeeInformationLookup(),
 				context::getBlockHeight, new BlockHeight[]{
-						this.feeForkDto.getFirstHeight(), this.feeForkDto.getSecondHeight()
+						this.feeFork.getFirstHeight(), this.feeFork.getSecondHeight()
 				});
 		return calculator.isFeeValid(transaction, context.getBlockHeight())
 				? ValidationResult.SUCCESS

--- a/nis/src/main/java/org/nem/nis/validators/transaction/MinimumFeeValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/MinimumFeeValidator.java
@@ -32,7 +32,7 @@ public class MinimumFeeValidator implements SingleTransactionValidator {
 	 * @param secondFeeForkHeight The second fee fork height.
 	 */
 	public MinimumFeeValidator(final NetworkInfo networkInfo, final ReadOnlyNamespaceCache namespaceCache, final boolean ignoreFees,
-							   final BlockHeight feeForkHeight, final BlockHeight secondFeeForkHeight) {
+			final BlockHeight feeForkHeight, final BlockHeight secondFeeForkHeight) {
 		this.networkInfo = networkInfo;
 		this.namespaceCache = namespaceCache;
 		this.ignoreFees = ignoreFees;
@@ -55,8 +55,7 @@ public class MinimumFeeValidator implements SingleTransactionValidator {
 		final NamespaceCacheLookupAdapters adapters = new NamespaceCacheLookupAdapters(this.namespaceCache);
 		final TransactionFeeCalculator calculator = new DefaultTransactionFeeCalculator(adapters.asMosaicFeeInformationLookup(),
 				context::getBlockHeight, new BlockHeight[]{
-						this.feeForkHeight,
-						this.secondFeeForkHeight
+						this.feeForkHeight, this.secondFeeForkHeight
 				});
 		return calculator.isFeeValid(transaction, context.getBlockHeight())
 				? ValidationResult.SUCCESS

--- a/nis/src/main/java/org/nem/nis/validators/transaction/MosaicDefinitionCreationTransactionValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/MosaicDefinitionCreationTransactionValidator.java
@@ -30,7 +30,7 @@ public class MosaicDefinitionCreationTransactionValidator implements TSingleTran
 	 * @param secondFeeForkHeight The second fee fork height.
 	 */
 	public MosaicDefinitionCreationTransactionValidator(final ReadOnlyNamespaceCache namespaceCache, final BlockHeight feeForkHeight,
-														final BlockHeight secondFeeForkHeight) {
+			final BlockHeight secondFeeForkHeight) {
 		this.namespaceCache = namespaceCache;
 		this.feeForkHeight = feeForkHeight;
 		this.secondFeeForkHeight = secondFeeForkHeight;
@@ -115,10 +115,9 @@ public class MosaicDefinitionCreationTransactionValidator implements TSingleTran
 	}
 
 	private static Amount getMosaicCreationFee(final int version, final BlockHeight height, final BlockHeight feeForkHeight,
-											   final BlockHeight secondFeeForkHeight) {
+			final BlockHeight secondFeeForkHeight) {
 		return feeForkHeight.getRaw() > height.getRaw()
 				? Amount.fromNem(50000)
-				: secondFeeForkHeight.getRaw() > height.getRaw() ? Amount.fromNem(500) :
-				Amount.fromNem(10);
+				: secondFeeForkHeight.getRaw() > height.getRaw() ? Amount.fromNem(500) : Amount.fromNem(10);
 	}
 }

--- a/nis/src/main/java/org/nem/nis/validators/transaction/MosaicDefinitionCreationTransactionValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/MosaicDefinitionCreationTransactionValidator.java
@@ -6,7 +6,7 @@ import org.nem.core.model.namespace.NamespaceId;
 import org.nem.core.model.primitive.*;
 import org.nem.nis.BlockMarkerConstants;
 import org.nem.nis.cache.*;
-import org.nem.nis.FeeForkDto;
+import org.nem.nis.FeeFork;
 import org.nem.nis.state.*;
 import org.nem.nis.validators.ValidationContext;
 
@@ -20,17 +20,17 @@ import java.util.Objects;
  */
 public class MosaicDefinitionCreationTransactionValidator implements TSingleTransactionValidator<MosaicDefinitionCreationTransaction> {
 	private final ReadOnlyNamespaceCache namespaceCache;
-	private final FeeForkDto feeForkDto;
+	private final FeeFork feeFork;
 
 	/**
 	 * Creates a validator.
 	 *
 	 * @param namespaceCache The namespace cache.
-	 * @param feeForkDto The fee fork heights.
+	 * @param feeFork The fee fork heights.
 	 */
-	public MosaicDefinitionCreationTransactionValidator(final ReadOnlyNamespaceCache namespaceCache, final FeeForkDto feeForkDto) {
+	public MosaicDefinitionCreationTransactionValidator(final ReadOnlyNamespaceCache namespaceCache, final FeeFork feeFork) {
 		this.namespaceCache = namespaceCache;
-		this.feeForkDto = feeForkDto;
+		this.feeFork = feeFork;
 	}
 
 	@Override
@@ -57,7 +57,7 @@ public class MosaicDefinitionCreationTransactionValidator implements TSingleTran
 			return ValidationResult.FAILURE_MOSAIC_INVALID_CREATION_FEE_SINK;
 		}
 
-		final Amount creationFee = getMosaicCreationFee(transaction.getVersion(), context.getBlockHeight(), this.feeForkDto);
+		final Amount creationFee = getMosaicCreationFee(transaction.getVersion(), context.getBlockHeight(), this.feeFork);
 		if (transaction.getCreationFee().compareTo(creationFee) < 0) {
 			return ValidationResult.FAILURE_MOSAIC_INVALID_CREATION_FEE;
 		}
@@ -110,9 +110,9 @@ public class MosaicDefinitionCreationTransactionValidator implements TSingleTran
 		return creatorBalance.equals(MosaicUtils.toQuantity(mosaicEntry.getSupply(), mosaicDefinition.getProperties().getDivisibility()));
 	}
 
-	private static Amount getMosaicCreationFee(final int version, final BlockHeight height, final FeeForkDto feeForkDto) {
-		return feeForkDto.getFirstHeight().getRaw() > height.getRaw()
+	private static Amount getMosaicCreationFee(final int version, final BlockHeight height, final FeeFork feeFork) {
+		return feeFork.getFirstHeight().getRaw() > height.getRaw()
 				? Amount.fromNem(50000)
-				: feeForkDto.getSecondHeight().getRaw() > height.getRaw() ? Amount.fromNem(500) : Amount.fromNem(10);
+				: feeFork.getSecondHeight().getRaw() > height.getRaw() ? Amount.fromNem(500) : Amount.fromNem(10);
 	}
 }

--- a/nis/src/main/java/org/nem/nis/validators/transaction/MultisigCosignatoryModificationValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/MultisigCosignatoryModificationValidator.java
@@ -34,8 +34,7 @@ public class MultisigCosignatoryModificationValidator implements TSingleTransact
 
 	@Override
 	public ValidationResult validate(final MultisigAggregateModificationTransaction transaction, final ValidationContext context) {
-		if (this.multisigMofNForkHeight.getRaw() > context.getBlockHeight().getRaw()
-				&& transaction.getEntityVersion() != 1) {
+		if (this.multisigMofNForkHeight.getRaw() > context.getBlockHeight().getRaw() && transaction.getEntityVersion() != 1) {
 			return ValidationResult.FAILURE_MULTISIG_V2_AGGREGATE_MODIFICATION_BEFORE_FORK;
 		}
 

--- a/nis/src/main/java/org/nem/nis/validators/transaction/MultisigCosignatoryModificationValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/MultisigCosignatoryModificationValidator.java
@@ -1,6 +1,7 @@
 package org.nem.nis.validators.transaction;
 
 import org.nem.core.model.*;
+import org.nem.core.model.primitive.BlockHeight;
 import org.nem.nis.BlockMarkerConstants;
 import org.nem.nis.cache.ReadOnlyAccountStateCache;
 import org.nem.nis.state.ReadOnlyAccountState;
@@ -18,19 +19,22 @@ import java.util.HashSet;
  */
 public class MultisigCosignatoryModificationValidator implements TSingleTransactionValidator<MultisigAggregateModificationTransaction> {
 	private final ReadOnlyAccountStateCache stateCache;
+	private final BlockHeight multisigMofNForkHeight;
 
 	/**
 	 * Creates a new validator.
 	 *
 	 * @param stateCache The account state cache.
+	 * @param multisigMofNForkHeight The multisig m-of-n fork height.
 	 */
-	public MultisigCosignatoryModificationValidator(final ReadOnlyAccountStateCache stateCache) {
+	public MultisigCosignatoryModificationValidator(final ReadOnlyAccountStateCache stateCache, final BlockHeight multisigMofNForkHeight) {
 		this.stateCache = stateCache;
+		this.multisigMofNForkHeight = multisigMofNForkHeight;
 	}
 
 	@Override
 	public ValidationResult validate(final MultisigAggregateModificationTransaction transaction, final ValidationContext context) {
-		if (BlockMarkerConstants.MULTISIG_M_OF_N_FORK(transaction.getVersion()) > context.getBlockHeight().getRaw()
+		if (this.multisigMofNForkHeight.getRaw() > context.getBlockHeight().getRaw()
 				&& transaction.getEntityVersion() != 1) {
 			return ValidationResult.FAILURE_MULTISIG_V2_AGGREGATE_MODIFICATION_BEFORE_FORK;
 		}

--- a/nis/src/main/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidator.java
@@ -34,7 +34,7 @@ public class ProvisionNamespaceTransactionValidator implements TSingleTransactio
 	 * @param secondFeeForkHeight The second fee fork height.
 	 */
 	public ProvisionNamespaceTransactionValidator(final ReadOnlyNamespaceCache namespaceCache, final BlockHeight feeForkHeight,
-												  final BlockHeight secondFeeForkHeight) {
+			final BlockHeight secondFeeForkHeight) {
 		this.namespaceCache = namespaceCache;
 		this.feeForkHeight = feeForkHeight;
 		this.secondFeeForkHeight = secondFeeForkHeight;
@@ -94,8 +94,10 @@ public class ProvisionNamespaceTransactionValidator implements TSingleTransactio
 		}
 
 		final Amount minimalRentalFee = 0 == resultingNamespaceId.getLevel()
-				? getRootNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight(), this.feeForkHeight, this.secondFeeForkHeight)
-				: getSubNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight(), this.feeForkHeight, this.secondFeeForkHeight);
+				? getRootNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight(), this.feeForkHeight,
+						this.secondFeeForkHeight)
+				: getSubNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight(), this.feeForkHeight,
+						this.secondFeeForkHeight);
 		if (minimalRentalFee.compareTo(transaction.getRentalFee()) > 0) {
 			return ValidationResult.FAILURE_NAMESPACE_INVALID_RENTAL_FEE;
 		}
@@ -113,17 +115,17 @@ public class ProvisionNamespaceTransactionValidator implements TSingleTransactio
 		return null == entry ? null : entry.getNamespace();
 	}
 
-	private static Amount getRootNamespaceRentalFee(final int version, final BlockHeight height, final BlockHeight feeForkHeight, final BlockHeight secondFeeForkHeight) {
+	private static Amount getRootNamespaceRentalFee(final int version, final BlockHeight height, final BlockHeight feeForkHeight,
+			final BlockHeight secondFeeForkHeight) {
 		return feeForkHeight.getRaw() > height.getRaw()
 				? Amount.fromNem(50000)
-				: secondFeeForkHeight.getRaw() > height.getRaw() ? Amount.fromNem(1500) :
-				Amount.fromNem(100);
+				: secondFeeForkHeight.getRaw() > height.getRaw() ? Amount.fromNem(1500) : Amount.fromNem(100);
 	}
 
-	private static Amount getSubNamespaceRentalFee(final int version, final BlockHeight height, final BlockHeight feeForkHeight, final BlockHeight secondFeeForkHeight) {
+	private static Amount getSubNamespaceRentalFee(final int version, final BlockHeight height, final BlockHeight feeForkHeight,
+			final BlockHeight secondFeeForkHeight) {
 		return feeForkHeight.getRaw() > height.getRaw()
 				? Amount.fromNem(5000)
-				: secondFeeForkHeight.getRaw() > height.getRaw() ? Amount.fromNem(200) :
-				Amount.fromNem(10);
+				: secondFeeForkHeight.getRaw() > height.getRaw() ? Amount.fromNem(200) : Amount.fromNem(10);
 	}
 }

--- a/nis/src/main/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidator.java
@@ -23,14 +23,21 @@ import org.nem.nis.validators.ValidationContext;
  */
 public class ProvisionNamespaceTransactionValidator implements TSingleTransactionValidator<ProvisionNamespaceTransaction> {
 	private final ReadOnlyNamespaceCache namespaceCache;
+	private final BlockHeight feeForkHeight;
+	private final BlockHeight secondFeeForkHeight;
 
 	/**
 	 * Creates a new validator.
 	 *
 	 * @param namespaceCache The namespace cache.
+	 * @param feeForkHeight The fee fork height.
+	 * @param secondFeeForkHeight The second fee fork height.
 	 */
-	public ProvisionNamespaceTransactionValidator(final ReadOnlyNamespaceCache namespaceCache) {
+	public ProvisionNamespaceTransactionValidator(final ReadOnlyNamespaceCache namespaceCache, final BlockHeight feeForkHeight,
+												  final BlockHeight secondFeeForkHeight) {
 		this.namespaceCache = namespaceCache;
+		this.feeForkHeight = feeForkHeight;
+		this.secondFeeForkHeight = secondFeeForkHeight;
 	}
 
 	@Override
@@ -87,8 +94,8 @@ public class ProvisionNamespaceTransactionValidator implements TSingleTransactio
 		}
 
 		final Amount minimalRentalFee = 0 == resultingNamespaceId.getLevel()
-				? getRootNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight())
-				: getSubNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight());
+				? getRootNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight(), this.feeForkHeight, this.secondFeeForkHeight)
+				: getSubNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight(), this.feeForkHeight, this.secondFeeForkHeight);
 		if (minimalRentalFee.compareTo(transaction.getRentalFee()) > 0) {
 			return ValidationResult.FAILURE_NAMESPACE_INVALID_RENTAL_FEE;
 		}
@@ -106,15 +113,17 @@ public class ProvisionNamespaceTransactionValidator implements TSingleTransactio
 		return null == entry ? null : entry.getNamespace();
 	}
 
-	private static Amount getRootNamespaceRentalFee(final int version, final BlockHeight height) {
-		return BlockMarkerConstants.FEE_FORK(version) > height.getRaw()
+	private static Amount getRootNamespaceRentalFee(final int version, final BlockHeight height, final BlockHeight feeForkHeight, final BlockHeight secondFeeForkHeight) {
+		return feeForkHeight.getRaw() > height.getRaw()
 				? Amount.fromNem(50000)
-				: BlockMarkerConstants.SECOND_FEE_FORK(version) > height.getRaw() ? Amount.fromNem(1500) : Amount.fromNem(100);
+				: secondFeeForkHeight.getRaw() > height.getRaw() ? Amount.fromNem(1500) :
+				Amount.fromNem(100);
 	}
 
-	private static Amount getSubNamespaceRentalFee(final int version, final BlockHeight height) {
-		return BlockMarkerConstants.FEE_FORK(version) > height.getRaw()
+	private static Amount getSubNamespaceRentalFee(final int version, final BlockHeight height, final BlockHeight feeForkHeight, final BlockHeight secondFeeForkHeight) {
+		return feeForkHeight.getRaw() > height.getRaw()
 				? Amount.fromNem(5000)
-				: BlockMarkerConstants.SECOND_FEE_FORK(version) > height.getRaw() ? Amount.fromNem(200) : Amount.fromNem(10);
+				: secondFeeForkHeight.getRaw() > height.getRaw() ? Amount.fromNem(200) :
+				Amount.fromNem(10);
 	}
 }

--- a/nis/src/main/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidator.java
@@ -6,7 +6,7 @@ import org.nem.core.model.namespace.*;
 import org.nem.core.model.primitive.*;
 import org.nem.nis.BlockMarkerConstants;
 import org.nem.nis.cache.ReadOnlyNamespaceCache;
-import org.nem.nis.FeeForkDto;
+import org.nem.nis.FeeFork;
 import org.nem.nis.state.ReadOnlyNamespaceEntry;
 import org.nem.nis.validators.ValidationContext;
 
@@ -24,17 +24,17 @@ import org.nem.nis.validators.ValidationContext;
  */
 public class ProvisionNamespaceTransactionValidator implements TSingleTransactionValidator<ProvisionNamespaceTransaction> {
 	private final ReadOnlyNamespaceCache namespaceCache;
-	private final FeeForkDto feeForkDto;
+	private final FeeFork feeFork;
 
 	/**
 	 * Creates a new validator.
 	 *
 	 * @param namespaceCache The namespace cache.
-	 * @param feeForkDto The fee fork heights.
+	 * @param feeFork The fee fork heights.
 	 */
-	public ProvisionNamespaceTransactionValidator(final ReadOnlyNamespaceCache namespaceCache, final FeeForkDto feeForkDto) {
+	public ProvisionNamespaceTransactionValidator(final ReadOnlyNamespaceCache namespaceCache, final FeeFork feeFork) {
 		this.namespaceCache = namespaceCache;
-		this.feeForkDto = feeForkDto;
+		this.feeFork = feeFork;
 	}
 
 	@Override
@@ -91,8 +91,8 @@ public class ProvisionNamespaceTransactionValidator implements TSingleTransactio
 		}
 
 		final Amount minimalRentalFee = 0 == resultingNamespaceId.getLevel()
-				? getRootNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight(), this.feeForkDto)
-				: getSubNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight(), this.feeForkDto);
+				? getRootNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight(), this.feeFork)
+				: getSubNamespaceRentalFee(transaction.getVersion(), context.getBlockHeight(), this.feeFork);
 		if (minimalRentalFee.compareTo(transaction.getRentalFee()) > 0) {
 			return ValidationResult.FAILURE_NAMESPACE_INVALID_RENTAL_FEE;
 		}
@@ -110,15 +110,15 @@ public class ProvisionNamespaceTransactionValidator implements TSingleTransactio
 		return null == entry ? null : entry.getNamespace();
 	}
 
-	private static Amount getRootNamespaceRentalFee(final int version, final BlockHeight height, final FeeForkDto feeForkDto) {
-		return feeForkDto.getFirstHeight().getRaw() > height.getRaw()
+	private static Amount getRootNamespaceRentalFee(final int version, final BlockHeight height, final FeeFork feeFork) {
+		return feeFork.getFirstHeight().getRaw() > height.getRaw()
 				? Amount.fromNem(50000)
-				: feeForkDto.getSecondHeight().getRaw() > height.getRaw() ? Amount.fromNem(1500) : Amount.fromNem(100);
+				: feeFork.getSecondHeight().getRaw() > height.getRaw() ? Amount.fromNem(1500) : Amount.fromNem(100);
 	}
 
-	private static Amount getSubNamespaceRentalFee(final int version, final BlockHeight height, final FeeForkDto feeForkDto) {
-		return feeForkDto.getFirstHeight().getRaw() > height.getRaw()
+	private static Amount getSubNamespaceRentalFee(final int version, final BlockHeight height, final FeeFork feeFork) {
+		return feeFork.getFirstHeight().getRaw() > height.getRaw()
 				? Amount.fromNem(5000)
-				: feeForkDto.getSecondHeight().getRaw() > height.getRaw() ? Amount.fromNem(200) : Amount.fromNem(10);
+				: feeFork.getSecondHeight().getRaw() > height.getRaw() ? Amount.fromNem(200) : Amount.fromNem(10);
 	}
 }

--- a/nis/src/main/java/org/nem/nis/validators/transaction/RemoteNonOperationalValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/RemoteNonOperationalValidator.java
@@ -14,14 +14,17 @@ import org.nem.nis.validators.*;
  */
 public class RemoteNonOperationalValidator implements SingleTransactionValidator {
 	private final ReadOnlyAccountStateCache stateCache;
+	private final BlockHeight mosaicRedefinitionForkHeight;
 
 	/**
 	 * Creates a new validator.
 	 *
 	 * @param stateCache The account state cache.
+	 * @param mosaicRedefinitionForkHeight The mosaic redefinition fork height.
 	 */
-	public RemoteNonOperationalValidator(final ReadOnlyAccountStateCache stateCache) {
+	public RemoteNonOperationalValidator(final ReadOnlyAccountStateCache stateCache, final BlockHeight mosaicRedefinitionForkHeight) {
 		this.stateCache = stateCache;
+		this.mosaicRedefinitionForkHeight = mosaicRedefinitionForkHeight;
 	}
 
 	@Override
@@ -42,7 +45,7 @@ public class RemoteNonOperationalValidator implements SingleTransactionValidator
 
 	private boolean isRemoteInactive(final Account account, final BlockHeight height) {
 		final ReadOnlyRemoteLinks remoteLinks = this.stateCache.findStateByAddress(account.getAddress()).getRemoteLinks();
-		if (height.getRaw() < BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(NetworkInfos.getDefault().getVersion() << 24)) {
+		if (height.getRaw() < this.mosaicRedefinitionForkHeight.getRaw()) {
 			return !remoteLinks.isRemoteHarvester();
 		}
 

--- a/nis/src/main/java/org/nem/nis/validators/transaction/TransferTransactionValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/TransferTransactionValidator.java
@@ -28,8 +28,7 @@ public class TransferTransactionValidator implements TSingleTransactionValidator
 
 	@Override
 	public ValidationResult validate(final TransferTransaction transaction, final ValidationContext context) {
-		final int maxMessageLength =
-				context.getBlockHeight().getRaw() >= this.remoteAccountForkHeight.getRaw()
+		final int maxMessageLength = context.getBlockHeight().getRaw() >= this.remoteAccountForkHeight.getRaw()
 				? CURRENT_MAX_MESSAGE_SIZE
 				: context.getBlockHeight().getRaw() >= this.multisigMOfNForkHeight.getRaw()
 						? MAX_MESSAGE_SIZE_MULTISIG_FORK

--- a/nis/src/main/java/org/nem/nis/validators/transaction/TransferTransactionValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/TransferTransactionValidator.java
@@ -1,6 +1,7 @@
 package org.nem.nis.validators.transaction;
 
 import org.nem.core.model.*;
+import org.nem.core.model.primitive.BlockHeight;
 import org.nem.nis.BlockMarkerConstants;
 import org.nem.nis.validators.ValidationContext;
 
@@ -11,12 +12,26 @@ public class TransferTransactionValidator implements TSingleTransactionValidator
 	private static final int ORIGINAL_MAX_MESSAGE_SIZE = 96;
 	private static final int MAX_MESSAGE_SIZE_MULTISIG_FORK = 160;
 	private static final int CURRENT_MAX_MESSAGE_SIZE = 1024;
+	private final BlockHeight remoteAccountForkHeight;
+	private final BlockHeight multisigMOfNForkHeight;
+
+	/**
+	 * Creates a transfer transaction validator.
+	 *
+	 * @param remoteAccountForkHeight The remote account fork height.
+	 * @param multisigMOfNForkHeight The multisig M-of-N fork height.
+	 */
+	public TransferTransactionValidator(final BlockHeight remoteAccountForkHeight, final BlockHeight multisigMOfNForkHeight) {
+		this.remoteAccountForkHeight = remoteAccountForkHeight;
+		this.multisigMOfNForkHeight = multisigMOfNForkHeight;
+	}
 
 	@Override
 	public ValidationResult validate(final TransferTransaction transaction, final ValidationContext context) {
-		final int maxMessageLength = context.getBlockHeight().getRaw() >= BlockMarkerConstants.REMOTE_ACCOUNT_FORK(transaction.getVersion())
+		final int maxMessageLength =
+				context.getBlockHeight().getRaw() >= this.remoteAccountForkHeight.getRaw()
 				? CURRENT_MAX_MESSAGE_SIZE
-				: context.getBlockHeight().getRaw() >= BlockMarkerConstants.MULTISIG_M_OF_N_FORK(transaction.getVersion())
+				: context.getBlockHeight().getRaw() >= this.multisigMOfNForkHeight.getRaw()
 						? MAX_MESSAGE_SIZE_MULTISIG_FORK
 						: ORIGINAL_MAX_MESSAGE_SIZE;
 		if (transaction.getMessageLength() > maxMessageLength) {

--- a/nis/src/main/java/org/nem/nis/validators/transaction/VersionTransactionValidator.java
+++ b/nis/src/main/java/org/nem/nis/validators/transaction/VersionTransactionValidator.java
@@ -1,7 +1,9 @@
 package org.nem.nis.validators.transaction;
 
 import org.nem.core.model.*;
+import org.nem.core.model.primitive.BlockHeight;
 import org.nem.nis.BlockMarkerConstants;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.validators.*;
 
 /**
@@ -9,6 +11,19 @@ import org.nem.nis.validators.*;
  * before the respective fork heights
  */
 public class VersionTransactionValidator implements SingleTransactionValidator {
+	private final BlockHeight mosaicsForkHeight;
+	private final BlockHeight multisigMOfNForkHeight;
+
+	/**
+	 * Creates a version transaction validator.
+	 *
+	 * @param mosaicsForkHeight The mosaics fork height.
+	 * @param multisigMOfNForkHeight The multisig M-of-N fork height.
+	 */
+	public VersionTransactionValidator(final BlockHeight mosaicsForkHeight, final BlockHeight multisigMOfNForkHeight) {
+		this.mosaicsForkHeight = mosaicsForkHeight;
+		this.multisigMOfNForkHeight = multisigMOfNForkHeight;
+	}
 
 	@Override
 	public ValidationResult validate(final Transaction transaction, final ValidationContext context) {
@@ -20,7 +35,7 @@ public class VersionTransactionValidator implements SingleTransactionValidator {
 			case TransactionTypes.MOSAIC_SUPPLY_CHANGE:
 				switch (version) {
 					case 1:
-						return blockHeight < BlockMarkerConstants.MOSAICS_FORK(transaction.getVersion())
+						return blockHeight < this.mosaicsForkHeight.getRaw()
 								? ValidationResult.FAILURE_TRANSACTION_BEFORE_SECOND_FORK
 								: ValidationResult.SUCCESS;
 				}
@@ -28,7 +43,7 @@ public class VersionTransactionValidator implements SingleTransactionValidator {
 			case TransactionTypes.TRANSFER:
 				switch (version) {
 					case 2:
-						return blockHeight < BlockMarkerConstants.MOSAICS_FORK(transaction.getVersion())
+						return blockHeight < this.mosaicsForkHeight.getRaw()
 								? ValidationResult.FAILURE_TRANSACTION_BEFORE_SECOND_FORK
 								: ValidationResult.SUCCESS;
 				}
@@ -36,7 +51,7 @@ public class VersionTransactionValidator implements SingleTransactionValidator {
 			case TransactionTypes.MULTISIG_AGGREGATE_MODIFICATION:
 				switch (version) {
 					case 2:
-						return blockHeight < BlockMarkerConstants.MULTISIG_M_OF_N_FORK(transaction.getVersion())
+						return blockHeight < this.multisigMOfNForkHeight.getRaw()
 								? ValidationResult.FAILURE_MULTISIG_V2_AGGREGATE_MODIFICATION_BEFORE_FORK
 								: ValidationResult.SUCCESS;
 				}

--- a/nis/src/main/java/org/nem/specific/deploy/NisConfiguration.java
+++ b/nis/src/main/java/org/nem/specific/deploy/NisConfiguration.java
@@ -89,7 +89,8 @@ public class NisConfiguration extends CommonConfiguration {
 		this.delayBlockLoading = properties.getOptionalBoolean("nis.delayBlockLoading", true);
 
 		this.blockChainConfiguration = parseBlockChainConfiguration(properties);
-		this.forkConfiguration = new ForkConfiguration.Builder(properties).build();
+
+		this.forkConfiguration = new ForkConfiguration.Builder(properties, this.getNetworkInfo()).build();
 	}
 
 	private static BlockChainConfiguration parseBlockChainConfiguration(final NemProperties properties) {

--- a/nis/src/main/java/org/nem/specific/deploy/NisConfiguration.java
+++ b/nis/src/main/java/org/nem/specific/deploy/NisConfiguration.java
@@ -89,7 +89,7 @@ public class NisConfiguration extends CommonConfiguration {
 		this.delayBlockLoading = properties.getOptionalBoolean("nis.delayBlockLoading", true);
 
 		this.blockChainConfiguration = parseBlockChainConfiguration(properties);
-		this.forkConfiguration = new ForkConfiguration(properties);
+		this.forkConfiguration = new ForkConfiguration.Builder(properties).build();
 	}
 
 	private static BlockChainConfiguration parseBlockChainConfiguration(final NemProperties properties) {

--- a/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
+++ b/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
@@ -301,26 +301,28 @@ public class NisAppConfig {
 
 	@Bean
 	public NisMain nisMain() {
+		final NisConfiguration nisConfiguration = this.nisConfiguration();
+
 		// initialize network info
-		NetworkInfos.setDefault(this.nisConfiguration().getNetworkInfo());
+		NetworkInfos.setDefault(nisConfiguration.getNetworkInfo());
 
 		// initialize other globals
 		final NamespaceCacheLookupAdapters adapters = new NamespaceCacheLookupAdapters(this.namespaceCache());
-		if (this.nisConfiguration().ignoreFees()) {
+		if (nisConfiguration.ignoreFees()) {
 			NemGlobals.setTransactionFeeCalculator(new ZeroTransactionFeeCalculator());
 		} else {
 			NemGlobals.setTransactionFeeCalculator(new DefaultTransactionFeeCalculator(adapters.asMosaicFeeInformationLookup(),
 					() -> this.blockChainLastBlockLayer.getLastBlockHeight().next(), new BlockHeight[]{
-							this.nisConfiguration().getForkConfiguration().getFeeForkHeight(),
-							this.nisConfiguration().getForkConfiguration().getSecondFeeForkHeight()
+							nisConfiguration.getForkConfiguration().getFeeForkHeight(),
+							nisConfiguration.getForkConfiguration().getSecondFeeForkHeight()
 					}));
 		}
 
-		NemGlobals.setBlockChainConfiguration(this.nisConfiguration().getBlockChainConfiguration());
+		NemGlobals.setBlockChainConfiguration(nisConfiguration.getBlockChainConfiguration());
 		NemStateGlobals.setWeightedBalancesSupplier(this.weighedBalancesSupplier());
 
 		return new NisMain(this.blockDao, this.nisCache(), this.networkHostBootstrapper(), this.nisModelToDbModelMapper(),
-				this.nisConfiguration(), this.blockAnalyzer(), System::exit);
+				nisConfiguration, this.blockAnalyzer(), System::exit);
 	}
 
 	@SuppressWarnings("serial")

--- a/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
+++ b/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
@@ -229,7 +229,8 @@ public class NisAppConfig {
 
 	@Bean
 	public SynchronizedNamespaceCache namespaceCache() {
-		return new SynchronizedNamespaceCache(new DefaultNamespaceCache(this.nisConfiguration().getForkConfiguration().getMosaicRedefinitionForkHeight()));
+		return new SynchronizedNamespaceCache(
+				new DefaultNamespaceCache(this.nisConfiguration().getForkConfiguration().getMosaicRedefinitionForkHeight()));
 	}
 
 	@Bean

--- a/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
+++ b/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
@@ -229,8 +229,10 @@ public class NisAppConfig {
 
 	@Bean
 	public SynchronizedNamespaceCache namespaceCache() {
-		return new SynchronizedNamespaceCache(
-				new DefaultNamespaceCache(this.nisConfiguration().getForkConfiguration().getMosaicRedefinitionForkHeight()));
+		final BlockHeight mosaicRedefinitionForkHeight = this.nisConfiguration().getForkConfiguration().getMosaicRedefinitionForkHeight();
+
+		NemNamespaceEntry.setDefault(mosaicRedefinitionForkHeight);
+		return new SynchronizedNamespaceCache(new DefaultNamespaceCache(mosaicRedefinitionForkHeight));
 	}
 
 	@Bean

--- a/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
+++ b/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
@@ -321,8 +321,8 @@ public class NisAppConfig {
 		NemGlobals.setBlockChainConfiguration(nisConfiguration.getBlockChainConfiguration());
 		NemStateGlobals.setWeightedBalancesSupplier(this.weighedBalancesSupplier());
 
-		return new NisMain(this.blockDao, this.nisCache(), this.networkHostBootstrapper(), this.nisModelToDbModelMapper(),
-				nisConfiguration, this.blockAnalyzer(), System::exit);
+		return new NisMain(this.blockDao, this.nisCache(), this.networkHostBootstrapper(), this.nisModelToDbModelMapper(), nisConfiguration,
+				this.blockAnalyzer(), System::exit);
 	}
 
 	@SuppressWarnings("serial")

--- a/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
+++ b/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
@@ -171,7 +171,8 @@ public class NisAppConfig {
 	@Bean
 	public BlockTransactionObserverFactory blockTransactionObserverFactory() {
 		final int estimatedBlocksPerYear = this.nisConfiguration().getBlockChainConfiguration().getEstimatedBlocksPerYear();
-		return new BlockTransactionObserverFactory(this.observerOptions(), estimatedBlocksPerYear);
+		final ForkConfiguration forkConfiguration = this.nisConfiguration().getForkConfiguration();
+		return new BlockTransactionObserverFactory(this.observerOptions(), estimatedBlocksPerYear, forkConfiguration);
 	}
 
 	@Bean
@@ -228,7 +229,7 @@ public class NisAppConfig {
 
 	@Bean
 	public SynchronizedNamespaceCache namespaceCache() {
-		return new SynchronizedNamespaceCache(new DefaultNamespaceCache());
+		return new SynchronizedNamespaceCache(new DefaultNamespaceCache(this.nisConfiguration().getForkConfiguration().getMosaicRedefinitionForkHeight()));
 	}
 
 	@Bean
@@ -309,9 +310,8 @@ public class NisAppConfig {
 		} else {
 			NemGlobals.setTransactionFeeCalculator(new DefaultTransactionFeeCalculator(adapters.asMosaicFeeInformationLookup(),
 					() -> this.blockChainLastBlockLayer.getLastBlockHeight().next(), new BlockHeight[]{
-							new BlockHeight(BlockMarkerConstants.FEE_FORK(this.nisConfiguration().getNetworkInfo().getVersion() << 24)),
-							new BlockHeight(
-									BlockMarkerConstants.SECOND_FEE_FORK(this.nisConfiguration().getNetworkInfo().getVersion() << 24))
+							this.nisConfiguration().getForkConfiguration().getFeeForkHeight(),
+							this.nisConfiguration().getForkConfiguration().getSecondFeeForkHeight()
 					}));
 		}
 
@@ -338,8 +338,9 @@ public class NisAppConfig {
 	@Bean
 	public BlockAnalyzer blockAnalyzer() {
 		final int estimatedBlocksPerYear = this.nisConfiguration().getBlockChainConfiguration().getEstimatedBlocksPerYear();
+		final ForkConfiguration forkConfiguration = this.nisConfiguration().getForkConfiguration();
 		return new BlockAnalyzer(this.blockDao, this.blockChainUpdater(), this.blockChainLastBlockLayer, this.nisMapperFactory(),
-				estimatedBlocksPerYear);
+				estimatedBlocksPerYear, forkConfiguration);
 	}
 
 	@Bean

--- a/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
+++ b/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
@@ -315,8 +315,8 @@ public class NisAppConfig {
 		} else {
 			NemGlobals.setTransactionFeeCalculator(new DefaultTransactionFeeCalculator(adapters.asMosaicFeeInformationLookup(),
 					() -> this.blockChainLastBlockLayer.getLastBlockHeight().next(), new BlockHeight[]{
-							nisConfiguration.getForkConfiguration().getFeeForkHeight(),
-							nisConfiguration.getForkConfiguration().getSecondFeeForkHeight()
+							nisConfiguration.getForkConfiguration().getFeeFork().getFirstHeight(),
+							nisConfiguration.getForkConfiguration().getFeeFork().getSecondHeight()
 					}));
 		}
 

--- a/nis/src/test/java/org/nem/nis/BlockAnalyzerTest.java
+++ b/nis/src/test/java/org/nem/nis/BlockAnalyzerTest.java
@@ -244,12 +244,13 @@ public class BlockAnalyzerTest {
 
 		private TestContext() {
 			final DefaultPoxFacade poxFacade = new DefaultPoxFacade(this.importanceCalculator);
-			this.nisCache = NisCacheFactory.createReal(poxFacade);
+			final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+			this.nisCache = NisCacheFactory.createReal(poxFacade, forkConfiguration.getMosaicRedefinitionForkHeight());
 			this.scoreManager = Mockito.spy(new MockBlockChainScoreManager(this.nisCache.getAccountStateCache()));
 			final MapperFactory mapperFactory = MapperUtils.createMapperFactory();
 			this.nisMapperFactory = Mockito.spy(new NisMapperFactory(mapperFactory));
 			this.blockAnalyzer = new BlockAnalyzer(this.blockDao, this.scoreManager, this.blockChainLastBlockLayer, this.nisMapperFactory,
-					ESTIMATED_BLOCKS_PER_YEAR);
+					ESTIMATED_BLOCKS_PER_YEAR, forkConfiguration);
 		}
 
 		private void fillDatabase(final Block nemesisBlock, final int numBlocks) {

--- a/nis/src/test/java/org/nem/nis/BlockChainValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/BlockChainValidatorTest.java
@@ -12,7 +12,6 @@ import org.nem.core.time.TimeInstant;
 import org.nem.nis.chain.BlockProcessor;
 import org.nem.nis.test.*;
 import org.nem.nis.validators.*;
-import org.nem.nis.ForkConfiguration;
 
 import java.math.BigInteger;
 import java.util.*;
@@ -251,7 +250,7 @@ public class BlockChainValidatorTest {
 	public void transactionsAtTreasuryReissuanceForkHeightDoNotNeedToVerify() {
 		// Arrange:
 		final BlockChainValidator validator = createValidator(
-				new ForkConfiguration(new BlockHeight(100), new ArrayList<Hash>(), new ArrayList<Hash>()));
+				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(100)).build());
 		final Block parentBlock = createParentBlock(Utils.generateRandomAccount(), 98);
 		parentBlock.sign();
 
@@ -649,7 +648,7 @@ public class BlockChainValidatorTest {
 		}
 
 		public BlockChainValidator create() {
-			return create(new ForkConfiguration());
+			return create(new ForkConfiguration.Builder().build());
 		}
 
 		public BlockChainValidator create(final ForkConfiguration forkConfiguration) {
@@ -659,7 +658,7 @@ public class BlockChainValidatorTest {
 	}
 
 	private static BlockChainValidator createValidator() {
-		return createValidator(new ForkConfiguration());
+		return createValidator(new ForkConfiguration.Builder().build());
 	}
 
 	private static BlockChainValidator createValidator(final ForkConfiguration forkConfiguration) {

--- a/nis/src/test/java/org/nem/nis/FeeForkTest.java
+++ b/nis/src/test/java/org/nem/nis/FeeForkTest.java
@@ -1,0 +1,23 @@
+package org.nem.nis;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.*;
+import org.junit.*;
+import org.nem.core.model.primitive.BlockHeight;
+
+public class FeeForkTest {
+
+	@Test
+	public void canCreateObject() {
+		// Arrange:
+		final BlockHeight firstHeight = new BlockHeight(1);
+		final BlockHeight secondHeight = new BlockHeight(2);
+
+		// Act:
+		final FeeFork feeFork = new FeeFork(firstHeight, secondHeight);
+
+		// Assert:
+		MatcherAssert.assertThat(feeFork.getFirstHeight(), IsSame.sameInstance(firstHeight));
+		MatcherAssert.assertThat(feeFork.getSecondHeight(), IsSame.sameInstance(secondHeight));
+	}
+}

--- a/nis/src/test/java/org/nem/nis/ForkConfigurationTest.java
+++ b/nis/src/test/java/org/nem/nis/ForkConfigurationTest.java
@@ -75,8 +75,7 @@ public class ForkConfigurationTest {
 		properties.setProperty("nis.treasuryReissuanceForkFallbackTransactionHashes", String.join("|", fallbackHashStrings));
 
 		// Act + Assert
-		ExceptionAssert.assertThrows(v -> new ForkConfiguration.Builder(new NemProperties(properties)).build(),
-				CryptoException.class);
+		ExceptionAssert.assertThrows(v -> new ForkConfiguration.Builder(new NemProperties(properties)).build(), CryptoException.class);
 	}
 
 	// endregion
@@ -97,11 +96,16 @@ public class ForkConfigurationTest {
 		MatcherAssert.assertThat(config.getTreasuryReissuanceForkFallbackTransactionHashes(), IsEqual.equalTo(new ArrayList<Hash>()));
 
 		MatcherAssert.assertThat(config.getFeeForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.FEE_FORK(version))));
-		MatcherAssert.assertThat(config.getSecondFeeForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.SECOND_FEE_FORK(version))));
-		MatcherAssert.assertThat(config.getMosaicsForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MOSAICS_FORK(version))));
-		MatcherAssert.assertThat(config.getmultisigMOfNForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MULTISIG_M_OF_N_FORK(version))));
-		MatcherAssert.assertThat(config.getRemoteAccountForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.REMOTE_ACCOUNT_FORK(version))));
-		MatcherAssert.assertThat(config.getMosaicRedefinitionForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(version))));
+		MatcherAssert.assertThat(config.getSecondFeeForkHeight(),
+				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.SECOND_FEE_FORK(version))));
+		MatcherAssert.assertThat(config.getMosaicsForkHeight(),
+				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MOSAICS_FORK(version))));
+		MatcherAssert.assertThat(config.getmultisigMOfNForkHeight(),
+				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MULTISIG_M_OF_N_FORK(version))));
+		MatcherAssert.assertThat(config.getRemoteAccountForkHeight(),
+				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.REMOTE_ACCOUNT_FORK(version))));
+		MatcherAssert.assertThat(config.getMosaicRedefinitionForkHeight(),
+				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(version))));
 	}
 
 	@Test
@@ -118,17 +122,11 @@ public class ForkConfigurationTest {
 		final List<Hash> fallbackHashes = Arrays.stream(fallbackHashStrings).map(Hash::fromHexString).collect(Collectors.toList());
 
 		// Act:
-		final ForkConfiguration config =
-				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
-						.treasuryReissuanceForkTransactionHashes(hashes)
-						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes)
-						.feeForkHeight(new BlockHeight(1))
-						.mosaicsForkHeight(new BlockHeight(2))
-						.multisigMOfNForkHeight(new BlockHeight(3))
-						.remoteAccountForkHeight(new BlockHeight(4))
-						.mosaicRedefinitionForkHeight(new BlockHeight(5))
-						.secondFeeForkHeight(new BlockHeight(6))
-						.build();
+		final ForkConfiguration config = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+				.treasuryReissuanceForkTransactionHashes(hashes).treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes)
+				.feeForkHeight(new BlockHeight(1)).mosaicsForkHeight(new BlockHeight(2)).multisigMOfNForkHeight(new BlockHeight(3))
+				.remoteAccountForkHeight(new BlockHeight(4)).mosaicRedefinitionForkHeight(new BlockHeight(5))
+				.secondFeeForkHeight(new BlockHeight(6)).build();
 
 		// Assert:
 		MatcherAssert.assertThat(config.getTreasuryReissuanceForkHeight(), IsEqual.equalTo(new BlockHeight(1234)));
@@ -158,11 +156,16 @@ public class ForkConfigurationTest {
 		MatcherAssert.assertThat(config.getTreasuryReissuanceForkFallbackTransactionHashes(), IsEqual.equalTo(new ArrayList<Hash>()));
 
 		MatcherAssert.assertThat(config.getFeeForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.FEE_FORK(version))));
-		MatcherAssert.assertThat(config.getSecondFeeForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.SECOND_FEE_FORK(version))));
-		MatcherAssert.assertThat(config.getMosaicsForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MOSAICS_FORK(version))));
-		MatcherAssert.assertThat(config.getmultisigMOfNForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MULTISIG_M_OF_N_FORK(version))));
-		MatcherAssert.assertThat(config.getRemoteAccountForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.REMOTE_ACCOUNT_FORK(version))));
-		MatcherAssert.assertThat(config.getMosaicRedefinitionForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(version))));
+		MatcherAssert.assertThat(config.getSecondFeeForkHeight(),
+				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.SECOND_FEE_FORK(version))));
+		MatcherAssert.assertThat(config.getMosaicsForkHeight(),
+				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MOSAICS_FORK(version))));
+		MatcherAssert.assertThat(config.getmultisigMOfNForkHeight(),
+				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MULTISIG_M_OF_N_FORK(version))));
+		MatcherAssert.assertThat(config.getRemoteAccountForkHeight(),
+				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.REMOTE_ACCOUNT_FORK(version))));
+		MatcherAssert.assertThat(config.getMosaicRedefinitionForkHeight(),
+				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(version))));
 	}
 
 	@Test

--- a/nis/src/test/java/org/nem/nis/ForkConfigurationTest.java
+++ b/nis/src/test/java/org/nem/nis/ForkConfigurationTest.java
@@ -114,7 +114,7 @@ public class ForkConfigurationTest {
 		final int version = NetworkInfos.getDefault().getVersion() << 24;
 
 		// Act +Assert:
-		assertCanReadConfiguration(version, () -> new ForkConfiguration.Builder().build());;
+		assertCanReadConfiguration(version, () -> new ForkConfiguration.Builder().build());
 	}
 
 	@Test

--- a/nis/src/test/java/org/nem/nis/ForkConfigurationTest.java
+++ b/nis/src/test/java/org/nem/nis/ForkConfigurationTest.java
@@ -37,7 +37,7 @@ public class ForkConfigurationTest {
 
 		properties.setProperty("nis.multisigMOfNForkHeight", "1");
 		properties.setProperty("nis.mosaicsForkHeight", "2");
-		properties.setProperty("nis.feeForkHeight", "3");
+		properties.setProperty("nis.firstFeeForkHeight", "3");
 		properties.setProperty("nis.remoteAccountForkHeight", "4");
 		properties.setProperty("nis.mosaicRedefinitionForkHeight", "5");
 		properties.setProperty("nis.secondFeeForkHeight", "6");
@@ -52,12 +52,12 @@ public class ForkConfigurationTest {
 		MatcherAssert.assertThat(config.getTreasuryReissuanceForkFallbackTransactionHashes(),
 				IsEqual.equalTo(Arrays.stream(fallbackHashStrings).map(Hash::fromHexString).collect(Collectors.toList())));
 
-		MatcherAssert.assertThat(config.getmultisigMOfNForkHeight(), IsEqual.equalTo(new BlockHeight(1)));
+		MatcherAssert.assertThat(config.getMultisigMOfNForkHeight(), IsEqual.equalTo(new BlockHeight(1)));
 		MatcherAssert.assertThat(config.getMosaicsForkHeight(), IsEqual.equalTo(new BlockHeight(2)));
-		MatcherAssert.assertThat(config.getFeeForkHeight(), IsEqual.equalTo(new BlockHeight(3)));
+		MatcherAssert.assertThat(config.getFeeFork().getFirstHeight(), IsEqual.equalTo(new BlockHeight(3)));
 		MatcherAssert.assertThat(config.getRemoteAccountForkHeight(), IsEqual.equalTo(new BlockHeight(4)));
 		MatcherAssert.assertThat(config.getMosaicRedefinitionForkHeight(), IsEqual.equalTo(new BlockHeight(5)));
-		MatcherAssert.assertThat(config.getSecondFeeForkHeight(), IsEqual.equalTo(new BlockHeight(6)));
+		MatcherAssert.assertThat(config.getFeeFork().getSecondHeight(), IsEqual.equalTo(new BlockHeight(6)));
 	}
 
 	private static void cannotParseWithInvalidHashes(final String separator, final String hashString) {
@@ -80,7 +80,7 @@ public class ForkConfigurationTest {
 		ExceptionAssert.assertThrows(v -> new ForkConfiguration.Builder(new NemProperties(properties)).build(), CryptoException.class);
 	}
 
-	private static void canReadConfiguration(final int version, final Supplier<ForkConfiguration> configSupplier) {
+	private static void assertCanReadConfiguration(final int version, final Supplier<ForkConfiguration> configSupplier) {
 
 		// Act:
 		final ForkConfiguration config = configSupplier.get();
@@ -90,12 +90,13 @@ public class ForkConfigurationTest {
 		MatcherAssert.assertThat(config.getTreasuryReissuanceForkTransactionHashes(), IsEqual.equalTo(new ArrayList<Hash>()));
 		MatcherAssert.assertThat(config.getTreasuryReissuanceForkFallbackTransactionHashes(), IsEqual.equalTo(new ArrayList<Hash>()));
 
-		MatcherAssert.assertThat(config.getFeeForkHeight(), IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.FEE_FORK(version))));
-		MatcherAssert.assertThat(config.getSecondFeeForkHeight(),
+		MatcherAssert.assertThat(config.getFeeFork().getFirstHeight(),
+				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.FEE_FORK(version))));
+		MatcherAssert.assertThat(config.getFeeFork().getSecondHeight(),
 				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.SECOND_FEE_FORK(version))));
 		MatcherAssert.assertThat(config.getMosaicsForkHeight(),
 				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MOSAICS_FORK(version))));
-		MatcherAssert.assertThat(config.getmultisigMOfNForkHeight(),
+		MatcherAssert.assertThat(config.getMultisigMOfNForkHeight(),
 				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MULTISIG_M_OF_N_FORK(version))));
 		MatcherAssert.assertThat(config.getRemoteAccountForkHeight(),
 				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.REMOTE_ACCOUNT_FORK(version))));
@@ -112,7 +113,8 @@ public class ForkConfigurationTest {
 		// Arrange:
 		final int version = NetworkInfos.getDefault().getVersion() << 24;
 
-		canReadConfiguration(version, () -> new ForkConfiguration.Builder().build());;
+		// Act +Assert:
+		assertCanReadConfiguration(version, () -> new ForkConfiguration.Builder().build());;
 	}
 
 	@Test
@@ -131,7 +133,7 @@ public class ForkConfigurationTest {
 		// Act:
 		final ForkConfiguration config = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
 				.treasuryReissuanceForkTransactionHashes(hashes).treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes)
-				.feeForkHeight(new BlockHeight(1)).mosaicsForkHeight(new BlockHeight(2)).multisigMOfNForkHeight(new BlockHeight(3))
+				.firstFeeForkHeight(new BlockHeight(1)).mosaicsForkHeight(new BlockHeight(2)).multisigMOfNForkHeight(new BlockHeight(3))
 				.remoteAccountForkHeight(new BlockHeight(4)).mosaicRedefinitionForkHeight(new BlockHeight(5))
 				.secondFeeForkHeight(new BlockHeight(6)).build();
 
@@ -140,12 +142,12 @@ public class ForkConfigurationTest {
 		MatcherAssert.assertThat(config.getTreasuryReissuanceForkTransactionHashes(), IsEqual.equalTo(hashes));
 		MatcherAssert.assertThat(config.getTreasuryReissuanceForkFallbackTransactionHashes(), IsEqual.equalTo(fallbackHashes));
 
-		MatcherAssert.assertThat(config.getFeeForkHeight(), IsEqual.equalTo(new BlockHeight(1)));
+		MatcherAssert.assertThat(config.getFeeFork().getFirstHeight(), IsEqual.equalTo(new BlockHeight(1)));
 		MatcherAssert.assertThat(config.getMosaicsForkHeight(), IsEqual.equalTo(new BlockHeight(2)));
-		MatcherAssert.assertThat(config.getmultisigMOfNForkHeight(), IsEqual.equalTo(new BlockHeight(3)));
+		MatcherAssert.assertThat(config.getMultisigMOfNForkHeight(), IsEqual.equalTo(new BlockHeight(3)));
 		MatcherAssert.assertThat(config.getRemoteAccountForkHeight(), IsEqual.equalTo(new BlockHeight(4)));
 		MatcherAssert.assertThat(config.getMosaicRedefinitionForkHeight(), IsEqual.equalTo(new BlockHeight(5)));
-		MatcherAssert.assertThat(config.getSecondFeeForkHeight(), IsEqual.equalTo(new BlockHeight(6)));
+		MatcherAssert.assertThat(config.getFeeFork().getSecondHeight(), IsEqual.equalTo(new BlockHeight(6)));
 	}
 
 	@Test
@@ -153,7 +155,8 @@ public class ForkConfigurationTest {
 		// Arrange:
 		final int version = NetworkInfos.getDefault().getVersion() << 24;
 
-		canReadConfiguration(version, () -> new ForkConfiguration.Builder(new NemProperties(new Properties())).build());;
+		// Act +Assert:
+		assertCanReadConfiguration(version, () -> new ForkConfiguration.Builder().build());
 	}
 
 	@Test
@@ -162,7 +165,8 @@ public class ForkConfigurationTest {
 		final NetworkInfo networkInfo = NetworkInfos.getMainNetworkInfo();
 		final int version = networkInfo.getVersion() << 24;
 
-		canReadConfiguration(version, () -> new ForkConfiguration.Builder(new NemProperties(new Properties()), networkInfo).build());
+		// Act +Assert:
+		assertCanReadConfiguration(version, () -> new ForkConfiguration.Builder(networkInfo).build());
 	}
 
 	@Test

--- a/nis/src/test/java/org/nem/nis/ForkConfigurationTest.java
+++ b/nis/src/test/java/org/nem/nis/ForkConfigurationTest.java
@@ -103,7 +103,6 @@ public class ForkConfigurationTest {
 				IsEqual.equalTo(new BlockHeight(BlockMarkerConstants.MOSAIC_REDEFINITION_FORK(version))));
 	}
 
-
 	// endregion
 
 	// region basic
@@ -165,7 +164,6 @@ public class ForkConfigurationTest {
 
 		canReadConfiguration(version, () -> new ForkConfiguration.Builder(new NemProperties(new Properties()), networkInfo).build());
 	}
-
 
 	@Test
 	public void canReadCustomConfiguration() {

--- a/nis/src/test/java/org/nem/nis/NemNamespaceEntryTest.java
+++ b/nis/src/test/java/org/nem/nis/NemNamespaceEntryTest.java
@@ -11,16 +11,13 @@ import org.nem.nis.state.*;
 
 public class NemNamespaceEntryTest {
 	private static final Supply NEM_XEM_SUPPLY = Supply.fromValue(8_999_999_999L);
-	private static final BlockHeight MOSAIC_REDEFINITION_FORK_HEIGHT = new ForkConfiguration.Builder().build()
-			.getMosaicRedefinitionForkHeight();
 
 	// region nem namespace entry
 
 	@Test
 	public void namespaceEntryNemHasExpectedNamespace() {
 		// Assert:
-		MatcherAssert.assertThat(NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT).getNamespace(),
-				IsEqual.equalTo(MosaicConstants.NAMESPACE_NEM));
+		MatcherAssert.assertThat(NemNamespaceEntry.getDefault().getNamespace(), IsEqual.equalTo(MosaicConstants.NAMESPACE_NEM));
 	}
 
 	@Test
@@ -29,7 +26,7 @@ public class NemNamespaceEntryTest {
 		final MosaicEntry mosaicEntry = getMosaicXemEntry();
 
 		// Assert:
-		MatcherAssert.assertThat(NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT).getMosaics().size(), IsEqual.equalTo(1));
+		MatcherAssert.assertThat(NemNamespaceEntry.getDefault().getMosaics().size(), IsEqual.equalTo(1));
 		MatcherAssert.assertThat(mosaicEntry.getMosaicDefinition(), IsEqual.equalTo(MosaicConstants.MOSAIC_DEFINITION_XEM));
 		MatcherAssert.assertThat(mosaicEntry.getSupply(), IsEqual.equalTo(NEM_XEM_SUPPLY));
 	}
@@ -37,7 +34,7 @@ public class NemNamespaceEntryTest {
 	@Test
 	public void namespaceEntryNemCannotHaveMosaicsAdded() {
 		// Arrange:
-		final NamespaceEntry entry = NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT);
+		final NamespaceEntry entry = NemNamespaceEntry.getDefault();
 
 		// Act:
 		ExceptionAssert.assertThrows(v -> entry.getMosaics().add(Utils.createMosaicDefinition(12)), UnsupportedOperationException.class);
@@ -49,7 +46,7 @@ public class NemNamespaceEntryTest {
 	@Test
 	public void namespaceEntryNemCannotHaveMosaicsRemoved() {
 		// Arrange:
-		final NamespaceEntry entry = NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT);
+		final NamespaceEntry entry = NemNamespaceEntry.getDefault();
 
 		// Act:
 		ExceptionAssert.assertThrows(v -> entry.getMosaics().remove(MosaicConstants.MOSAIC_DEFINITION_XEM.getId()),
@@ -90,7 +87,6 @@ public class NemNamespaceEntryTest {
 	// endregion
 
 	private static MosaicEntry getMosaicXemEntry() {
-		return NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT).getMosaics()
-				.get(new MosaicId(MosaicConstants.NAMESPACE_ID_NEM, "xem"));
+		return NemNamespaceEntry.getDefault().getMosaics().get(new MosaicId(MosaicConstants.NAMESPACE_ID_NEM, "xem"));
 	}
 }

--- a/nis/src/test/java/org/nem/nis/NemNamespaceEntryTest.java
+++ b/nis/src/test/java/org/nem/nis/NemNamespaceEntryTest.java
@@ -11,14 +11,16 @@ import org.nem.nis.state.*;
 
 public class NemNamespaceEntryTest {
 	private static final Supply NEM_XEM_SUPPLY = Supply.fromValue(8_999_999_999L);
-	private static final BlockHeight MOSAIC_REDEFINITION_FORK_HEIGHT = new ForkConfiguration.Builder().build().getMosaicRedefinitionForkHeight();
+	private static final BlockHeight MOSAIC_REDEFINITION_FORK_HEIGHT = new ForkConfiguration.Builder().build()
+			.getMosaicRedefinitionForkHeight();
 
 	// region nem namespace entry
 
 	@Test
 	public void namespaceEntryNemHasExpectedNamespace() {
 		// Assert:
-		MatcherAssert.assertThat(NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT).getNamespace(), IsEqual.equalTo(MosaicConstants.NAMESPACE_NEM));
+		MatcherAssert.assertThat(NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT).getNamespace(),
+				IsEqual.equalTo(MosaicConstants.NAMESPACE_NEM));
 	}
 
 	@Test
@@ -88,6 +90,7 @@ public class NemNamespaceEntryTest {
 	// endregion
 
 	private static MosaicEntry getMosaicXemEntry() {
-		return NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT).getMosaics().get(new MosaicId(MosaicConstants.NAMESPACE_ID_NEM, "xem"));
+		return NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT).getMosaics()
+				.get(new MosaicId(MosaicConstants.NAMESPACE_ID_NEM, "xem"));
 	}
 }

--- a/nis/src/test/java/org/nem/nis/NemNamespaceEntryTest.java
+++ b/nis/src/test/java/org/nem/nis/NemNamespaceEntryTest.java
@@ -4,19 +4,21 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.*;
 import org.junit.*;
 import org.nem.core.model.mosaic.*;
+import org.nem.core.model.primitive.BlockHeight;
 import org.nem.core.model.primitive.Supply;
 import org.nem.core.test.*;
 import org.nem.nis.state.*;
 
-public class NamespaceConstantsTest {
+public class NemNamespaceEntryTest {
 	private static final Supply NEM_XEM_SUPPLY = Supply.fromValue(8_999_999_999L);
+	private static final BlockHeight MOSAIC_REDEFINITION_FORK_HEIGHT = new ForkConfiguration.Builder().build().getMosaicRedefinitionForkHeight();
 
 	// region nem namespace entry
 
 	@Test
 	public void namespaceEntryNemHasExpectedNamespace() {
 		// Assert:
-		MatcherAssert.assertThat(NamespaceConstants.NAMESPACE_ENTRY_NEM.getNamespace(), IsEqual.equalTo(MosaicConstants.NAMESPACE_NEM));
+		MatcherAssert.assertThat(NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT).getNamespace(), IsEqual.equalTo(MosaicConstants.NAMESPACE_NEM));
 	}
 
 	@Test
@@ -25,7 +27,7 @@ public class NamespaceConstantsTest {
 		final MosaicEntry mosaicEntry = getMosaicXemEntry();
 
 		// Assert:
-		MatcherAssert.assertThat(NamespaceConstants.NAMESPACE_ENTRY_NEM.getMosaics().size(), IsEqual.equalTo(1));
+		MatcherAssert.assertThat(NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT).getMosaics().size(), IsEqual.equalTo(1));
 		MatcherAssert.assertThat(mosaicEntry.getMosaicDefinition(), IsEqual.equalTo(MosaicConstants.MOSAIC_DEFINITION_XEM));
 		MatcherAssert.assertThat(mosaicEntry.getSupply(), IsEqual.equalTo(NEM_XEM_SUPPLY));
 	}
@@ -33,7 +35,7 @@ public class NamespaceConstantsTest {
 	@Test
 	public void namespaceEntryNemCannotHaveMosaicsAdded() {
 		// Arrange:
-		final NamespaceEntry entry = NamespaceConstants.NAMESPACE_ENTRY_NEM;
+		final NamespaceEntry entry = NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT);
 
 		// Act:
 		ExceptionAssert.assertThrows(v -> entry.getMosaics().add(Utils.createMosaicDefinition(12)), UnsupportedOperationException.class);
@@ -45,7 +47,7 @@ public class NamespaceConstantsTest {
 	@Test
 	public void namespaceEntryNemCannotHaveMosaicsRemoved() {
 		// Arrange:
-		final NamespaceEntry entry = NamespaceConstants.NAMESPACE_ENTRY_NEM;
+		final NamespaceEntry entry = NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT);
 
 		// Act:
 		ExceptionAssert.assertThrows(v -> entry.getMosaics().remove(MosaicConstants.MOSAIC_DEFINITION_XEM.getId()),
@@ -86,6 +88,6 @@ public class NamespaceConstantsTest {
 	// endregion
 
 	private static MosaicEntry getMosaicXemEntry() {
-		return NamespaceConstants.NAMESPACE_ENTRY_NEM.getMosaics().get(new MosaicId(MosaicConstants.NAMESPACE_ID_NEM, "xem"));
+		return NemNamespaceEntry.getInstance(MOSAIC_REDEFINITION_FORK_HEIGHT).getMosaics().get(new MosaicId(MosaicConstants.NAMESPACE_ID_NEM, "xem"));
 	}
 }

--- a/nis/src/test/java/org/nem/nis/NemNamespaceEntryTest.java
+++ b/nis/src/test/java/org/nem/nis/NemNamespaceEntryTest.java
@@ -12,6 +12,11 @@ import org.nem.nis.state.*;
 public class NemNamespaceEntryTest {
 	private static final Supply NEM_XEM_SUPPLY = Supply.fromValue(8_999_999_999L);
 
+	@After
+	public void resetDefaultNamespaceEntry() {
+		NemNamespaceEntry.resetToDefault();
+	}
+
 	// region nem namespace entry
 
 	@Test
@@ -54,6 +59,40 @@ public class NemNamespaceEntryTest {
 
 		// Assert:
 		MatcherAssert.assertThat(entry.getMosaics().size(), IsEqual.equalTo(1));
+	}
+
+	@Test
+	public void defaultNamespaceEntryCanBeChanged() {
+		// Arrange:
+		final NamespaceEntry entry = NemNamespaceEntry.getDefault();
+
+		// Act:
+		NemNamespaceEntry.setDefault(new BlockHeight(10));
+
+		// Assert:
+		MatcherAssert.assertThat(NemNamespaceEntry.getDefault(), IsNot.not(IsEqual.equalTo(entry)));
+	}
+
+	@Test
+	public void defaultNamespaceEntryCanBeReset() {
+		// Arrange:
+		final NamespaceEntry entry = NemNamespaceEntry.getDefault();
+		NemNamespaceEntry.setDefault(new BlockHeight(2));
+
+		// Act:
+		NemNamespaceEntry.resetToDefault();
+
+		// Assert:
+		MatcherAssert.assertThat(NemNamespaceEntry.getDefault(), IsSame.sameInstance(entry));
+	}
+
+	@Test
+	public void defaultNetworkCannotBeChangedAfterBeingSet() {
+		// Arrange:
+		NemNamespaceEntry.setDefault(new BlockHeight(20));
+
+		// Act:
+		ExceptionAssert.assertThrows(v -> NemNamespaceEntry.setDefault(new BlockHeight(1)), IllegalStateException.class);
 	}
 
 	// endregion

--- a/nis/src/test/java/org/nem/nis/NisMainTest.java
+++ b/nis/src/test/java/org/nem/nis/NisMainTest.java
@@ -438,13 +438,15 @@ public class NisMainTest {
 			this.mapper = Mockito.spy(MapperUtils.createModelToDbModelNisMapperAccountDao(accountDao));
 
 			final DefaultPoxFacade poxFacade = new DefaultPoxFacade(new MockImportanceCalculator());
-			this.nisCache = NisCacheFactory.createReal(poxFacade);
+			this.nisConfiguration = createNisConfiguration(autoBoot, supplyBootKey, supplyBootName, delayBlockLoading,
+					historicalAccountData, proofOfStake);
+			this.nisCache = NisCacheFactory.createReal(poxFacade, this.nisConfiguration.getForkConfiguration().getMosaicRedefinitionForkHeight());
 			final BlockChainScoreManager scoreManager = new MockBlockChainScoreManager(this.nisCache.getAccountStateCache());
 			final MapperFactory mapperFactory = MapperUtils.createMapperFactory();
 			final NisMapperFactory nisMapperFactory = new NisMapperFactory(mapperFactory);
 			this.blockChainLastBlockLayer = new BlockChainLastBlockLayer(blockDao, this.mapper);
 			final BlockAnalyzer blockAnalyzer = new BlockAnalyzer(blockDao, scoreManager, this.blockChainLastBlockLayer, nisMapperFactory,
-					ESTIMATED_BLOCKS_PER_YEAR);
+					ESTIMATED_BLOCKS_PER_YEAR, this.nisConfiguration.getForkConfiguration());
 			this.nemesisBlock = blockAnalyzer.loadNemesisBlock();
 			this.blockAnalyzer = Mockito.spy(blockAnalyzer);
 			Mockito.when(this.networkHost.boot(Mockito.any())).thenAnswer(invocationOnMock -> {
@@ -454,8 +456,7 @@ public class NisMainTest {
 
 				return CompletableFuture.completedFuture(null);
 			});
-			this.nisConfiguration = createNisConfiguration(autoBoot, supplyBootKey, supplyBootName, delayBlockLoading,
-					historicalAccountData, proofOfStake);
+
 			this.nisMain = new NisMain(blockDao, this.nisCache, this.networkHost, this.mapper, this.nisConfiguration, this.blockAnalyzer,
 					i -> this.exitReason[0] = i);
 		}

--- a/nis/src/test/java/org/nem/nis/NisMainTest.java
+++ b/nis/src/test/java/org/nem/nis/NisMainTest.java
@@ -440,7 +440,8 @@ public class NisMainTest {
 			final DefaultPoxFacade poxFacade = new DefaultPoxFacade(new MockImportanceCalculator());
 			this.nisConfiguration = createNisConfiguration(autoBoot, supplyBootKey, supplyBootName, delayBlockLoading,
 					historicalAccountData, proofOfStake);
-			this.nisCache = NisCacheFactory.createReal(poxFacade, this.nisConfiguration.getForkConfiguration().getMosaicRedefinitionForkHeight());
+			this.nisCache = NisCacheFactory.createReal(poxFacade,
+					this.nisConfiguration.getForkConfiguration().getMosaicRedefinitionForkHeight());
 			final BlockChainScoreManager scoreManager = new MockBlockChainScoreManager(this.nisCache.getAccountStateCache());
 			final MapperFactory mapperFactory = MapperUtils.createMapperFactory();
 			final NisMapperFactory nisMapperFactory = new NisMapperFactory(mapperFactory);

--- a/nis/src/test/java/org/nem/nis/cache/DefaultNamespaceCacheTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/DefaultNamespaceCacheTest.java
@@ -1,9 +1,12 @@
 package org.nem.nis.cache;
 
+import org.nem.nis.ForkConfiguration;
+
 public class DefaultNamespaceCacheTest extends NamespaceCacheTest<DefaultNamespaceCache> {
 
 	@Override
 	protected DefaultNamespaceCache createImmutableCache() {
-		return new DefaultNamespaceCache();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		return new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight());
 	}
 }

--- a/nis/src/test/java/org/nem/nis/cache/NamespaceCacheLookupAdaptersTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/NamespaceCacheLookupAdaptersTest.java
@@ -8,6 +8,7 @@ import org.nem.core.model.mosaic.*;
 import org.nem.core.model.namespace.*;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
+import org.nem.nis.ForkConfiguration;
 
 public class NamespaceCacheLookupAdaptersTest {
 
@@ -98,7 +99,8 @@ public class NamespaceCacheLookupAdaptersTest {
 	// endregion
 
 	private static class TestContext {
-		private final NamespaceCache cache = new DefaultNamespaceCache().copy();
+		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		private final NamespaceCache cache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 		private final NamespaceCacheLookupAdapters adapters = new NamespaceCacheLookupAdapters(this.cache);
 		private final MosaicLevy levy = Utils.createMosaicLevy();
 

--- a/nis/src/test/java/org/nem/nis/cache/NamespaceCacheTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/NamespaceCacheTest.java
@@ -978,7 +978,7 @@ public abstract class NamespaceCacheTest<T extends ExtendedNamespaceCache<T>> {
 
 		// Assert:
 		MatcherAssert.assertThat(namespaceEntry, IsNull.notNullValue());
-		MatcherAssert.assertThat(namespaceEntry, IsSame.sameInstance(NemNamespaceEntry.getInstance(mosaicRedefinitionForkHeight)));
+		MatcherAssert.assertThat(namespaceEntry, IsSame.sameInstance(NemNamespaceEntry.getDefault()));
 	}
 
 	@Test

--- a/nis/src/test/java/org/nem/nis/cache/NamespaceCacheTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/NamespaceCacheTest.java
@@ -971,7 +971,6 @@ public abstract class NamespaceCacheTest<T extends ExtendedNamespaceCache<T>> {
 	public void getReturnsExpectedNemNamespaceEntry() {
 		// Arrange:
 		final T cache = this.createCache();
-		final BlockHeight mosaicRedefinitionForkHeight = new ForkConfiguration.Builder().build().getMosaicRedefinitionForkHeight();
 
 		// Act:
 		final NamespaceEntry namespaceEntry = cache.get(new NamespaceId("nem"));

--- a/nis/src/test/java/org/nem/nis/cache/NamespaceCacheTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/NamespaceCacheTest.java
@@ -8,7 +8,8 @@ import org.nem.core.model.mosaic.MosaicId;
 import org.nem.core.model.namespace.*;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.*;
-import org.nem.nis.NamespaceConstants;
+import org.nem.nis.ForkConfiguration;
+import org.nem.nis.NemNamespaceEntry;
 import org.nem.nis.state.*;
 
 import java.util.*;
@@ -970,13 +971,14 @@ public abstract class NamespaceCacheTest<T extends ExtendedNamespaceCache<T>> {
 	public void getReturnsExpectedNemNamespaceEntry() {
 		// Arrange:
 		final T cache = this.createCache();
+		final BlockHeight mosaicRedefinitionForkHeight = new ForkConfiguration.Builder().build().getMosaicRedefinitionForkHeight();
 
 		// Act:
 		final NamespaceEntry namespaceEntry = cache.get(new NamespaceId("nem"));
 
 		// Assert:
 		MatcherAssert.assertThat(namespaceEntry, IsNull.notNullValue());
-		MatcherAssert.assertThat(namespaceEntry, IsSame.sameInstance(NamespaceConstants.NAMESPACE_ENTRY_NEM));
+		MatcherAssert.assertThat(namespaceEntry, IsSame.sameInstance(NemNamespaceEntry.getInstance(mosaicRedefinitionForkHeight)));
 	}
 
 	@Test

--- a/nis/src/test/java/org/nem/nis/cache/NamespaceCacheUtilsTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/NamespaceCacheUtilsTest.java
@@ -8,6 +8,7 @@ import org.nem.core.model.mosaic.*;
 import org.nem.core.model.namespace.*;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.*;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.state.ReadOnlyMosaicEntry;
 
 import java.util.*;
@@ -187,7 +188,8 @@ public class NamespaceCacheUtilsTest {
 	// endregion
 
 	private static NamespaceCache createCache() {
-		final DefaultNamespaceCache cache = new DefaultNamespaceCache().copy();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		final DefaultNamespaceCache cache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 		cache.add(new Namespace(new NamespaceId("foo"), Utils.generateRandomAccount(), BlockHeight.ONE));
 		cache.get(new NamespaceId("foo")).getMosaics().add(Utils.createMosaicDefinition("foo", "tokens"));
 		cache.commit();

--- a/nis/src/test/java/org/nem/nis/cache/SynchronizedNamespaceCacheTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/SynchronizedNamespaceCacheTest.java
@@ -1,9 +1,12 @@
 package org.nem.nis.cache;
 
+import org.nem.nis.ForkConfiguration;
+
 public class SynchronizedNamespaceCacheTest extends NamespaceCacheTest<SynchronizedNamespaceCache> {
 
 	@Override
 	protected SynchronizedNamespaceCache createImmutableCache() {
-		return new SynchronizedNamespaceCache(new DefaultNamespaceCache());
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		return new SynchronizedNamespaceCache(new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()));
 	}
 }

--- a/nis/src/test/java/org/nem/nis/chain/integration/BlockChainHarvesterTest.java
+++ b/nis/src/test/java/org/nem/nis/chain/integration/BlockChainHarvesterTest.java
@@ -9,6 +9,7 @@ import org.nem.core.model.mosaic.MosaicId;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.*;
 import org.nem.core.utils.ExceptionUtils;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.dbmodel.DbMosaicId;
 import org.nem.nis.state.*;
@@ -264,10 +265,12 @@ public class BlockChainHarvesterTest {
 	@Test
 	public void processBlockUpdatesBlockLessor() {
 		// Arrange:
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		final SynchronizedAccountStateCache accountStateCache = new SynchronizedAccountStateCache(new DefaultAccountStateCache());
 		final DefaultNisCache nisCache = new DefaultNisCache(new SynchronizedAccountCache(new DefaultAccountCache()), accountStateCache,
 				new SynchronizedPoxFacade(new DefaultPoxFacade(NisUtils.createImportanceCalculator())),
-				new SynchronizedHashCache(new DefaultHashCache()), new SynchronizedNamespaceCache(new DefaultNamespaceCache()));
+				new SynchronizedHashCache(new DefaultHashCache()),
+				new SynchronizedNamespaceCache(new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight())));
 		final RealBlockChainTestContext context = new RealBlockChainTestContext(nisCache);
 
 		// Setup remote harvesting

--- a/nis/src/test/java/org/nem/nis/chain/integration/RealBlockChainTestContext.java
+++ b/nis/src/test/java/org/nem/nis/chain/integration/RealBlockChainTestContext.java
@@ -39,8 +39,9 @@ public class RealBlockChainTestContext {
 			this.mapperFactory.createModelToDbModelMapper(new AccountDaoLookupAdapter(this.accountDao)));
 	private final BlockChainLastBlockLayer blockChainLastBlockLayer = new BlockChainLastBlockLayer(this.blockDao,
 			this.nisModelToDbModelMapper);
+	private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 
-	private final BlockTransactionObserverFactory blockTransactionObserverFactory = new BlockTransactionObserverFactory();
+	private final BlockTransactionObserverFactory blockTransactionObserverFactory = new BlockTransactionObserverFactory(forkConfiguration);
 	private final BlockValidatorFactory blockValidatorFactory = NisUtils.createBlockValidatorFactory();
 	private final TransactionValidatorFactory transactionValidatorFactory = NisUtils.createTransactionValidatorFactory();
 	private final NisMapperFactory nisMapperFactory = new NisMapperFactory(this.mapperFactory);

--- a/nis/src/test/java/org/nem/nis/harvesting/DefaultNewBlockTransactionsProviderTest.java
+++ b/nis/src/test/java/org/nem/nis/harvesting/DefaultNewBlockTransactionsProviderTest.java
@@ -137,8 +137,7 @@ public class DefaultNewBlockTransactionsProviderTest {
 
 		// - create test context and add account
 		final TestContext context = new TestContext(new ProviderFactories((transaction, context2) -> ValidationResult.SUCCESS),
-				new ForkConfiguration.Builder()
-						.treasuryReissuanceForkHeight(new BlockHeight(1234))
+				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
 						.treasuryReissuanceForkTransactionHashes(hashes).build());
 		context.addTransactions(transactions);
 
@@ -172,8 +171,7 @@ public class DefaultNewBlockTransactionsProviderTest {
 
 		// - create test context and add account
 		final TestContext context = new TestContext(new ProviderFactories((transaction, context2) -> ValidationResult.SUCCESS),
-				new ForkConfiguration.Builder()
-						.treasuryReissuanceForkHeight(new BlockHeight(1234))
+				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
 						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build());
 		context.addTransactions(transactions);
 
@@ -214,8 +212,8 @@ public class DefaultNewBlockTransactionsProviderTest {
 		// - create test context and add account
 		final TestContext context = new TestContext(new ProviderFactories((transaction, context2) -> ValidationResult.SUCCESS),
 				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
-						.treasuryReissuanceForkTransactionHashes(hashes)
-						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build());
+						.treasuryReissuanceForkTransactionHashes(hashes).treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes)
+						.build());
 		context.addTransactions(transactions);
 
 		// - create accounts

--- a/nis/src/test/java/org/nem/nis/harvesting/DefaultNewBlockTransactionsProviderTest.java
+++ b/nis/src/test/java/org/nem/nis/harvesting/DefaultNewBlockTransactionsProviderTest.java
@@ -137,7 +137,9 @@ public class DefaultNewBlockTransactionsProviderTest {
 
 		// - create test context and add account
 		final TestContext context = new TestContext(new ProviderFactories((transaction, context2) -> ValidationResult.SUCCESS),
-				new ForkConfiguration(new BlockHeight(1234), hashes, new ArrayList<Hash>()));
+				new ForkConfiguration.Builder()
+						.treasuryReissuanceForkHeight(new BlockHeight(1234))
+						.treasuryReissuanceForkTransactionHashes(hashes).build());
 		context.addTransactions(transactions);
 
 		// - create accounts
@@ -170,7 +172,9 @@ public class DefaultNewBlockTransactionsProviderTest {
 
 		// - create test context and add account
 		final TestContext context = new TestContext(new ProviderFactories((transaction, context2) -> ValidationResult.SUCCESS),
-				new ForkConfiguration(new BlockHeight(1234), new ArrayList<Hash>(), fallbackHashes));
+				new ForkConfiguration.Builder()
+						.treasuryReissuanceForkHeight(new BlockHeight(1234))
+						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build());
 		context.addTransactions(transactions);
 
 		// - create accounts
@@ -209,7 +213,9 @@ public class DefaultNewBlockTransactionsProviderTest {
 
 		// - create test context and add account
 		final TestContext context = new TestContext(new ProviderFactories((transaction, context2) -> ValidationResult.SUCCESS),
-				new ForkConfiguration(new BlockHeight(1234), hashes, fallbackHashes));
+				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+						.treasuryReissuanceForkTransactionHashes(hashes)
+						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build());
 		context.addTransactions(transactions);
 
 		// - create accounts
@@ -541,7 +547,7 @@ public class DefaultNewBlockTransactionsProviderTest {
 			final ProviderFactories factories = new ProviderFactories();
 			factories.validatorFactory = NisUtils.createTransactionValidatorFactory();
 			factories.blockValidatorFactory = NisUtils.createBlockValidatorFactory();
-			factories.observerFactory = new BlockTransactionObserverFactory();
+			factories.observerFactory = new BlockTransactionObserverFactory(new ForkConfiguration.Builder().build());
 			return factories;
 		}
 
@@ -599,11 +605,11 @@ public class DefaultNewBlockTransactionsProviderTest {
 		}
 
 		public TestContext(final SingleTransactionValidator singleValidator) {
-			this(new ProviderFactories(singleValidator), new ForkConfiguration());
+			this(new ProviderFactories(singleValidator), new ForkConfiguration.Builder().build());
 		}
 
 		public TestContext(final ProviderFactories factories) {
-			this(factories, new ForkConfiguration());
+			this(factories, new ForkConfiguration.Builder().build());
 		}
 
 		public TestContext(final ProviderFactories factories, final ForkConfiguration forkConfiguration) {

--- a/nis/src/test/java/org/nem/nis/harvesting/DefaultUnconfirmedStateTest.java
+++ b/nis/src/test/java/org/nem/nis/harvesting/DefaultUnconfirmedStateTest.java
@@ -167,9 +167,8 @@ public class DefaultUnconfirmedStateTest {
 			hashes.add(Utils.generateRandomHash());
 
 			// - create test context and add account
-			final TestContext context =
-					new TestContext(new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
-							.treasuryReissuanceForkTransactionHashes(hashes).build());
+			final TestContext context = new TestContext(new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+					.treasuryReissuanceForkTransactionHashes(hashes).build());
 			context.prepareAccount(senderAccount, Amount.fromNem(1_000));
 
 			// Act:

--- a/nis/src/test/java/org/nem/nis/harvesting/DefaultUnconfirmedStateTest.java
+++ b/nis/src/test/java/org/nem/nis/harvesting/DefaultUnconfirmedStateTest.java
@@ -167,7 +167,9 @@ public class DefaultUnconfirmedStateTest {
 			hashes.add(Utils.generateRandomHash());
 
 			// - create test context and add account
-			final TestContext context = new TestContext(new ForkConfiguration(new BlockHeight(1234), hashes, new ArrayList<Hash>()));
+			final TestContext context =
+					new TestContext(new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+							.treasuryReissuanceForkTransactionHashes(hashes).build());
 			context.prepareAccount(senderAccount, Amount.fromNem(1_000));
 
 			// Act:
@@ -641,7 +643,7 @@ public class DefaultUnconfirmedStateTest {
 		private long blockHeight = CONFIRMED_BLOCK_HEIGHT;
 
 		public TestContext(final SingleTransactionValidator... additionalValidators) {
-			this(new ForkConfiguration(), additionalValidators);
+			this(new ForkConfiguration.Builder().build(), additionalValidators);
 		}
 
 		public TestContext(final ForkConfiguration forkConfiguration, final SingleTransactionValidator... additionalValidators) {

--- a/nis/src/test/java/org/nem/nis/harvesting/UnconfirmedStateFactoryTest.java
+++ b/nis/src/test/java/org/nem/nis/harvesting/UnconfirmedStateFactoryTest.java
@@ -18,7 +18,7 @@ public class UnconfirmedStateFactoryTest {
 		// Arrange:
 		final UnconfirmedStateFactory factory = new UnconfirmedStateFactory(NisUtils.createTransactionValidatorFactory(),
 				cache -> Mockito.mock(BlockTransactionObserver.class), Mockito.mock(TimeProvider.class), () -> BlockHeight.MAX,
-				NisTestConstants.MAX_TRANSACTIONS_PER_BLOCK, new ForkConfiguration());
+				NisTestConstants.MAX_TRANSACTIONS_PER_BLOCK, new ForkConfiguration.Builder().build());
 
 		// Act:
 		final UnconfirmedState state = factory.create(Mockito.mock(NisCache.class), Mockito.mock(UnconfirmedTransactionsCache.class));

--- a/nis/src/test/java/org/nem/nis/harvesting/UnconfirmedTransactionsOtherTest.java
+++ b/nis/src/test/java/org/nem/nis/harvesting/UnconfirmedTransactionsOtherTest.java
@@ -327,7 +327,8 @@ public abstract class UnconfirmedTransactionsOtherTest implements UnconfirmedTra
 			final TimeProvider timeProvider = Utils.createMockTimeProvider(CURRENT_TIME);
 			final UnconfirmedStateFactory factory = new UnconfirmedStateFactory(NisUtils.createTransactionValidatorFactory(timeProvider),
 					NisUtils.createBlockTransactionObserverFactory()::createExecuteCommitObserver, timeProvider,
-					() -> new BlockHeight(1234), NisTestConstants.MAX_TRANSACTIONS_PER_BLOCK, new ForkConfiguration());
+					() -> new BlockHeight(1234), NisTestConstants.MAX_TRANSACTIONS_PER_BLOCK,
+					new ForkConfiguration.Builder().build());
 			this.transactions = creator.apply(factory, this.nisCache);
 		}
 

--- a/nis/src/test/java/org/nem/nis/harvesting/UnconfirmedTransactionsOtherTest.java
+++ b/nis/src/test/java/org/nem/nis/harvesting/UnconfirmedTransactionsOtherTest.java
@@ -327,8 +327,7 @@ public abstract class UnconfirmedTransactionsOtherTest implements UnconfirmedTra
 			final TimeProvider timeProvider = Utils.createMockTimeProvider(CURRENT_TIME);
 			final UnconfirmedStateFactory factory = new UnconfirmedStateFactory(NisUtils.createTransactionValidatorFactory(timeProvider),
 					NisUtils.createBlockTransactionObserverFactory()::createExecuteCommitObserver, timeProvider,
-					() -> new BlockHeight(1234), NisTestConstants.MAX_TRANSACTIONS_PER_BLOCK,
-					new ForkConfiguration.Builder().build());
+					() -> new BlockHeight(1234), NisTestConstants.MAX_TRANSACTIONS_PER_BLOCK, new ForkConfiguration.Builder().build());
 			this.transactions = creator.apply(factory, this.nisCache);
 		}
 

--- a/nis/src/test/java/org/nem/nis/secret/AccountInfoMosaicIdsObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/AccountInfoMosaicIdsObserverTest.java
@@ -9,6 +9,7 @@ import org.nem.core.model.namespace.*;
 import org.nem.core.model.observers.*;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.*;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.state.AccountInfo;
 import org.nem.nis.test.NisUtils;
@@ -196,7 +197,8 @@ public class AccountInfoMosaicIdsObserverTest {
 		private final Account sender = this.mosaicDefinition.getCreator();
 		private final Account recipient = Utils.generateRandomAccount();
 		private final Account recipient2 = Utils.generateRandomAccount();
-		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache().copy();
+		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 		private final AccountStateCache accountStateCache = new DefaultAccountStateCache().copy();
 
 		public TestContext() {

--- a/nis/src/test/java/org/nem/nis/secret/AccountInfoMosaicIdsObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/AccountInfoMosaicIdsObserverTest.java
@@ -198,7 +198,8 @@ public class AccountInfoMosaicIdsObserverTest {
 		private final Account recipient = Utils.generateRandomAccount();
 		private final Account recipient2 = Utils.generateRandomAccount();
 		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
-		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
+		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight())
+				.copy();
 		private final AccountStateCache accountStateCache = new DefaultAccountStateCache().copy();
 
 		public TestContext() {

--- a/nis/src/test/java/org/nem/nis/secret/BlockTransactionObserverFactoryTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/BlockTransactionObserverFactoryTest.java
@@ -10,6 +10,7 @@ import org.nem.core.model.observers.*;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.*;
 import org.nem.core.time.TimeInstant;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.state.*;
 import org.nem.nis.test.*;
@@ -22,33 +23,34 @@ public class BlockTransactionObserverFactoryTest {
 	private static final EnumSet<ObserverOption> OPTIONS_NO_OUTLINK_OBSERVER = EnumSet.of(ObserverOption.NoOutlinkObserver);
 	private static final EnumSet<ObserverOption> OPTIONS_NONE = EnumSet.range(ObserverOption.NoIncrementalPoi,
 			ObserverOption.NoOutlinkObserver);
+	private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 
 	// region basic - execute
 
 	@Test
 	public void createExecuteCommitObserverReturnsValidObserver() {
 		// Assert:
-		assertExecuteCommitObserverNames(new BlockTransactionObserverFactory(), getDefaultObserverNames());
+		assertExecuteCommitObserverNames(new BlockTransactionObserverFactory(forkConfiguration), getDefaultObserverNames());
 	}
 
 	@Test
 	public void createExecuteCommitObserverWithNoIncrementalPoiReturnsValidObserver() {
 		// Assert:
-		assertExecuteCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NO_INCREMENTAL_POI),
+		assertExecuteCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NO_INCREMENTAL_POI, forkConfiguration),
 				getObserverNamesWithoutIncrementalPoi());
 	}
 
 	@Test
 	public void createExecuteCommitObserverWithNoOutlinkObserverReturnsValidObserver() {
 		// Assert:
-		assertExecuteCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NO_OUTLINK_OBSERVER),
+		assertExecuteCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NO_OUTLINK_OBSERVER, forkConfiguration),
 				getObserverNamesWithoutOutlinkObserver());
 	}
 
 	@Test
 	public void createExecuteCommitObserverWithNoOptionalObserverReturnsValidObserver() {
 		// Assert:
-		assertExecuteCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NONE), getBaseObserverNames());
+		assertExecuteCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NONE, forkConfiguration), getBaseObserverNames());
 	}
 
 	private static void assertExecuteCommitObserverNames(final BlockTransactionObserverFactory factory,
@@ -71,27 +73,27 @@ public class BlockTransactionObserverFactoryTest {
 	@Test
 	public void createUndoCommitObserverReturnsValidObserver() {
 		// Assert:
-		assertUndoCommitObserverNames(new BlockTransactionObserverFactory(), getDefaultObserverNames());
+		assertUndoCommitObserverNames(new BlockTransactionObserverFactory(forkConfiguration), getDefaultObserverNames());
 	}
 
 	@Test
 	public void createUndoCommitObserverWithNoIncrementalPoiReturnsValidObserver() {
 		// Assert:
-		assertUndoCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NO_INCREMENTAL_POI),
+		assertUndoCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NO_INCREMENTAL_POI, forkConfiguration),
 				getObserverNamesWithoutIncrementalPoi());
 	}
 
 	@Test
 	public void createUndoCommitObserverWithNoOutlinkObserverReturnsValidObserver() {
 		// Assert:
-		assertUndoCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NO_OUTLINK_OBSERVER),
+		assertUndoCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NO_OUTLINK_OBSERVER, forkConfiguration),
 				getObserverNamesWithoutOutlinkObserver());
 	}
 
 	@Test
 	public void createUndoCommitObserverWithNoOptionalObserverReturnsValidObserver() {
 		// Assert:
-		assertUndoCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NONE), getBaseObserverNames());
+		assertUndoCommitObserverNames(new BlockTransactionObserverFactory(OPTIONS_NONE, forkConfiguration), getBaseObserverNames());
 	}
 
 	private static void assertUndoCommitObserverNames(final BlockTransactionObserverFactory factory,
@@ -167,7 +169,7 @@ public class BlockTransactionObserverFactoryTest {
 	@Test
 	public void createExecuteDoesPerformIncrementalPoiWhenEnabled() {
 		// Arrange:
-		final BlockTransactionObserverFactory factory = new BlockTransactionObserverFactory();
+		final BlockTransactionObserverFactory factory = new BlockTransactionObserverFactory(forkConfiguration);
 
 		// Assert:
 		assertRecalculateImportancesIsCalled(factory::createExecuteCommitObserver, NotificationTrigger.Execute);
@@ -176,7 +178,7 @@ public class BlockTransactionObserverFactoryTest {
 	@Test
 	public void createExecuteDoesNotPerformIncrementalPoiWhenDisabled() {
 		// Arrange:
-		final BlockTransactionObserverFactory factory = new BlockTransactionObserverFactory(OPTIONS_NO_INCREMENTAL_POI);
+		final BlockTransactionObserverFactory factory = new BlockTransactionObserverFactory(OPTIONS_NO_INCREMENTAL_POI, forkConfiguration);
 
 		// Assert:
 		assertRecalculateImportancesIsNotCalled(factory::createExecuteCommitObserver, NotificationTrigger.Execute);
@@ -185,7 +187,7 @@ public class BlockTransactionObserverFactoryTest {
 	@Test
 	public void createUndoDoesPerformIncrementalPoiWhenEnabled() {
 		// Arrange:
-		final BlockTransactionObserverFactory factory = new BlockTransactionObserverFactory();
+		final BlockTransactionObserverFactory factory = new BlockTransactionObserverFactory(forkConfiguration);
 
 		// Assert:
 		assertRecalculateImportancesIsCalled(factory::createUndoCommitObserver, NotificationTrigger.Undo);
@@ -194,7 +196,7 @@ public class BlockTransactionObserverFactoryTest {
 	@Test
 	public void createUndoDoesNotPerformIncrementalPoiWhenDisabled() {
 		// Arrange:
-		final BlockTransactionObserverFactory factory = new BlockTransactionObserverFactory(OPTIONS_NO_INCREMENTAL_POI);
+		final BlockTransactionObserverFactory factory = new BlockTransactionObserverFactory(OPTIONS_NO_INCREMENTAL_POI, forkConfiguration);
 
 		// Assert:
 		assertRecalculateImportancesIsNotCalled(factory::createUndoCommitObserver, NotificationTrigger.Undo);
@@ -432,7 +434,7 @@ public class BlockTransactionObserverFactoryTest {
 		}
 
 		public TestContext(final EnumSet<ObserverOption> observerOptions) {
-			this.factory = new BlockTransactionObserverFactory(observerOptions);
+			this.factory = new BlockTransactionObserverFactory(observerOptions, new ForkConfiguration.Builder().build());
 		}
 
 		private MockAccountContext addAccount() {

--- a/nis/src/test/java/org/nem/nis/secret/ExpiredNamespacesObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/ExpiredNamespacesObserverTest.java
@@ -9,6 +9,7 @@ import org.nem.core.model.namespace.*;
 import org.nem.core.model.observers.*;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.*;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.state.*;
 import org.nem.nis.test.NisUtils;
@@ -115,7 +116,8 @@ public class ExpiredNamespacesObserverTest {
 	private static class TestContext {
 		private final MosaicDefinition mosaicDefinition1 = Utils.createMosaicDefinition(1, createMosaicProperties());
 		private final MosaicDefinition mosaicDefinition2 = Utils.createMosaicDefinition(2, createMosaicProperties());
-		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache().copy();
+		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 		private final DefaultAccountStateCache accountStateCache = Mockito.mock(DefaultAccountStateCache.class);
 		private final AccountInfo accountInfo1;
 		private final AccountInfo accountInfo2;

--- a/nis/src/test/java/org/nem/nis/secret/ExpiredNamespacesObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/ExpiredNamespacesObserverTest.java
@@ -117,7 +117,8 @@ public class ExpiredNamespacesObserverTest {
 		private final MosaicDefinition mosaicDefinition1 = Utils.createMosaicDefinition(1, createMosaicProperties());
 		private final MosaicDefinition mosaicDefinition2 = Utils.createMosaicDefinition(2, createMosaicProperties());
 		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
-		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
+		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight())
+				.copy();
 		private final DefaultAccountStateCache accountStateCache = Mockito.mock(DefaultAccountStateCache.class);
 		private final AccountInfo accountInfo1;
 		private final AccountInfo accountInfo2;

--- a/nis/src/test/java/org/nem/nis/secret/MosaicDefinitionCreationObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/MosaicDefinitionCreationObserverTest.java
@@ -10,6 +10,7 @@ import org.nem.core.model.observers.*;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
 import org.nem.nis.BlockMarkerConstants;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.state.MosaicEntry;
 import org.nem.nis.test.NisUtils;
@@ -168,7 +169,8 @@ public class MosaicDefinitionCreationObserverTest {
 	private class TestContext {
 		private final MosaicDefinition mosaicDefinition = Utils.createMosaicDefinition(7,
 				Utils.createMosaicPropertiesWithInitialSupply(5L));
-		private final NamespaceCache namespaceCache = new DefaultNamespaceCache().copy();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		private final NamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 
 		public TestContext() {
 			this.namespaceCache.add(

--- a/nis/src/test/java/org/nem/nis/secret/MosaicSupplyChangeObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/MosaicSupplyChangeObserverTest.java
@@ -10,6 +10,7 @@ import org.nem.core.model.namespace.*;
 import org.nem.core.model.observers.*;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.state.*;
 import org.nem.nis.test.NisUtils;
@@ -118,7 +119,8 @@ public class MosaicSupplyChangeObserverTest {
 	private static class TestContext {
 		private final MosaicDefinition mosaicDefinition = Utils.createMosaicDefinition(1, createMosaicProperties());
 		private final Account supplier = this.mosaicDefinition.getCreator();
-		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache().copy();
+		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 		private final AccountStateCache accountStateCache = Mockito.mock(AccountStateCache.class);
 		private final AccountState accountState = new AccountState(this.supplier.getAddress());
 

--- a/nis/src/test/java/org/nem/nis/secret/MosaicSupplyChangeObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/MosaicSupplyChangeObserverTest.java
@@ -120,7 +120,8 @@ public class MosaicSupplyChangeObserverTest {
 		private final MosaicDefinition mosaicDefinition = Utils.createMosaicDefinition(1, createMosaicProperties());
 		private final Account supplier = this.mosaicDefinition.getCreator();
 		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
-		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
+		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight())
+				.copy();
 		private final AccountStateCache accountStateCache = Mockito.mock(AccountStateCache.class);
 		private final AccountState accountState = new AccountState(this.supplier.getAddress());
 

--- a/nis/src/test/java/org/nem/nis/secret/MosaicTransferObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/MosaicTransferObserverTest.java
@@ -9,6 +9,7 @@ import org.nem.core.model.namespace.*;
 import org.nem.core.model.observers.*;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.DefaultNamespaceCache;
 import org.nem.nis.state.*;
 import org.nem.nis.test.NisUtils;
@@ -78,7 +79,8 @@ public class MosaicTransferObserverTest {
 		private final MosaicDefinition mosaicDefinition = Utils.createMosaicDefinition(1, createMosaicProperties());
 		private final Account sender = this.mosaicDefinition.getCreator();
 		private final Account recipient = Utils.generateRandomAccount();
-		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache().copy();
+		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 
 		private TestContext() {
 			final NamespaceId namespaceId = this.mosaicDefinition.getId().getNamespaceId();

--- a/nis/src/test/java/org/nem/nis/secret/MosaicTransferObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/MosaicTransferObserverTest.java
@@ -80,7 +80,8 @@ public class MosaicTransferObserverTest {
 		private final Account sender = this.mosaicDefinition.getCreator();
 		private final Account recipient = Utils.generateRandomAccount();
 		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
-		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
+		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight())
+				.copy();
 
 		private TestContext() {
 			final NamespaceId namespaceId = this.mosaicDefinition.getId().getNamespaceId();

--- a/nis/src/test/java/org/nem/nis/secret/ProvisionNamespaceObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/ProvisionNamespaceObserverTest.java
@@ -10,6 +10,7 @@ import org.nem.core.model.namespace.*;
 import org.nem.core.model.observers.*;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.*;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.test.NisUtils;
 
@@ -59,7 +60,8 @@ public class ProvisionNamespaceObserverTest {
 		List<Address> coinsOwners = Arrays.asList(Utils.generateRandomAddress(), namespaceOwner.getAddress());
 
 		// - namespace cache setup
-		final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache().copy();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 		addNamespace(namespaceCache, namespaceOwner, "foo");
 		addNamespace(namespaceCache, namespaceOwner, "foo.bar");
 		addMosaic(namespaceCache, "foo", "tokens");

--- a/nis/src/test/java/org/nem/nis/secret/RemoteObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/RemoteObserverTest.java
@@ -194,7 +194,8 @@ public class RemoteObserverTest {
 		private final RemoteLinks fakeLesseeRemoteLinks = Mockito.mock(RemoteLinks.class);
 		private final AccountStateCache accountStateCache = Mockito.mock(AccountStateCache.class);
 		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
-		private final BlockTransactionObserver observer = new RemoteObserver(this.accountStateCache, this.forkConfiguration.getMosaicRedefinitionForkHeight());
+		private final BlockTransactionObserver observer = new RemoteObserver(this.accountStateCache,
+				this.forkConfiguration.getMosaicRedefinitionForkHeight());
 
 		private TestContext() {
 			this.hook(this.lessor, this.lessorRemoteLinks);

--- a/nis/src/test/java/org/nem/nis/secret/RemoteObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/RemoteObserverTest.java
@@ -7,6 +7,7 @@ import org.nem.core.model.observers.*;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
 import org.nem.nis.BlockMarkerConstants;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.AccountStateCache;
 import org.nem.nis.state.*;
 import org.nem.nis.test.*;
@@ -192,7 +193,8 @@ public class RemoteObserverTest {
 		private final RemoteLinks lesseeRemoteLinks = Mockito.mock(RemoteLinks.class);
 		private final RemoteLinks fakeLesseeRemoteLinks = Mockito.mock(RemoteLinks.class);
 		private final AccountStateCache accountStateCache = Mockito.mock(AccountStateCache.class);
-		private final BlockTransactionObserver observer = new RemoteObserver(this.accountStateCache);
+		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		private final BlockTransactionObserver observer = new RemoteObserver(this.accountStateCache, this.forkConfiguration.getMosaicRedefinitionForkHeight());
 
 		private TestContext() {
 			this.hook(this.lessor, this.lessorRemoteLinks);

--- a/nis/src/test/java/org/nem/nis/service/MosaicInfoFactoryTest.java
+++ b/nis/src/test/java/org/nem/nis/service/MosaicInfoFactoryTest.java
@@ -11,6 +11,7 @@ import org.nem.core.model.namespace.*;
 import org.nem.core.model.primitive.BlockHeight;
 import org.nem.core.model.primitive.Quantity;
 import org.nem.core.test.Utils;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.ReadOnlyAccountStateCache;
 import org.nem.nis.cache.ReadOnlyNamespaceCache;
 import org.nem.nis.dao.ReadOnlyNamespaceDao;
@@ -61,8 +62,9 @@ public class MosaicInfoFactoryTest {
 			this.accountState.getAccountInfo().addMosaicId(mosaicId2);
 			Mockito.when(this.accountStateCache.findStateByAddress(this.address)).thenReturn(this.accountState);
 
+			final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 			final Namespace namespace = new Namespace(namespaceId1, Utils.generateRandomAccount(), BlockHeight.ONE);
-			final Mosaics mosaics = new Mosaics(namespace.getId());
+			final Mosaics mosaics = new Mosaics(namespace.getId(), forkConfiguration.getMosaicRedefinitionForkHeight());
 			mosaics.add(Utils.createMosaicDefinition(namespaceId1.toString(), mosaicId1.getName()));
 			final MosaicEntry mosaicEntry = mosaics.get(mosaicId1);
 			mosaicEntry.getBalances().incrementBalance(this.address, new Quantity(1234));

--- a/nis/src/test/java/org/nem/nis/state/MosaicsTest.java
+++ b/nis/src/test/java/org/nem/nis/state/MosaicsTest.java
@@ -7,12 +7,14 @@ import org.nem.core.model.mosaic.*;
 import org.nem.core.model.namespace.NamespaceId;
 import org.nem.core.model.primitive.Supply;
 import org.nem.core.test.*;
+import org.nem.nis.ForkConfiguration;
 
 import java.util.*;
 import java.util.stream.IntStream;
 
 public class MosaicsTest {
 	private static final String DEFAULT_NID = "vouchers";
+	private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 
 	// region constructor
 
@@ -473,6 +475,6 @@ public class MosaicsTest {
 	}
 
 	private Mosaics createCache() {
-		return new Mosaics(new NamespaceId(DEFAULT_NID));
+		return new Mosaics(new NamespaceId(DEFAULT_NID), this.forkConfiguration.getMosaicRedefinitionForkHeight());
 	}
 }

--- a/nis/src/test/java/org/nem/nis/state/NamespaceEntryTest.java
+++ b/nis/src/test/java/org/nem/nis/state/NamespaceEntryTest.java
@@ -6,14 +6,17 @@ import org.junit.*;
 import org.nem.core.model.namespace.*;
 import org.nem.core.model.primitive.BlockHeight;
 import org.nem.core.test.Utils;
+import org.nem.nis.ForkConfiguration;
 
 public class NamespaceEntryTest {
+
+	private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 
 	@Test
 	public void canCreateEntry() {
 		// Arrange:
 		final Namespace namespace = new Namespace(new NamespaceId("foo"), Utils.generateRandomAccount(), BlockHeight.ONE);
-		final Mosaics mosaics = new Mosaics(namespace.getId());
+		final Mosaics mosaics = new Mosaics(namespace.getId(), this.forkConfiguration.getMosaicRedefinitionForkHeight());
 		mosaics.add(Utils.createMosaicDefinition(namespace.getId(), 1));
 
 		// Act:
@@ -28,7 +31,7 @@ public class NamespaceEntryTest {
 	public void canCreateEntryCopy() {
 		// Arrange:
 		final Namespace namespace = new Namespace(new NamespaceId("foo"), Utils.generateRandomAccount(), BlockHeight.ONE);
-		final Mosaics mosaics = new Mosaics(namespace.getId());
+		final Mosaics mosaics = new Mosaics(namespace.getId(), this.forkConfiguration.getMosaicRedefinitionForkHeight());
 		mosaics.add(Utils.createMosaicDefinition(namespace.getId(), 1));
 		final NamespaceEntry entry = new NamespaceEntry(namespace, mosaics);
 

--- a/nis/src/test/java/org/nem/nis/sync/BlockChainServicesTest.java
+++ b/nis/src/test/java/org/nem/nis/sync/BlockChainServicesTest.java
@@ -27,7 +27,8 @@ public class BlockChainServicesTest {
 		// note: createMapper() only uses the NisMapperFactory object
 		final NisMapperFactory factory = Mockito.mock(NisMapperFactory.class);
 		final AccountLookup lookup = new DefaultAccountCache();
-		final BlockChainServices services = new BlockChainServices(null, null, null, null, factory, new ForkConfiguration());
+		final BlockChainServices services = new BlockChainServices(null, null, null, null, factory,
+				new ForkConfiguration.Builder().build());
 
 		// Act:
 		services.createMapper(lookup);

--- a/nis/src/test/java/org/nem/nis/sync/DefaultMosaicDebitPredicateTest.java
+++ b/nis/src/test/java/org/nem/nis/sync/DefaultMosaicDebitPredicateTest.java
@@ -8,6 +8,7 @@ import org.nem.core.model.mosaic.*;
 import org.nem.core.model.namespace.Namespace;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.state.*;
 import org.nem.nis.validators.DebitPredicate;
@@ -63,6 +64,7 @@ public class DefaultMosaicDebitPredicateTest {
 	}
 
 	private static NamespaceCache createNamespaceCache() {
-		return new DefaultNamespaceCache().copy();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		return new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 	}
 }

--- a/nis/src/test/java/org/nem/nis/test/BlockChain/BlockChainContext.java
+++ b/nis/src/test/java/org/nem/nis/test/BlockChain/BlockChainContext.java
@@ -51,7 +51,8 @@ public class BlockChainContext {
 				.forEach(a -> a.getImportanceInfo().setImportance(blockHeight, 1.0 / accountStates.size()));
 		final DefaultPoxFacade poxFacade = new DefaultPoxFacade(importanceCalculator);
 		final NisConfiguration nisConfiguration = new NisConfiguration();
-		final ReadOnlyNisCache commonNisCache = NisCacheFactory.createReal(poxFacade, nisConfiguration.getForkConfiguration().getMosaicRedefinitionForkHeight());
+		final ReadOnlyNisCache commonNisCache = NisCacheFactory.createReal(poxFacade,
+				nisConfiguration.getForkConfiguration().getMosaicRedefinitionForkHeight());
 		this.scorer = new BlockScorer(commonNisCache.getAccountStateCache());
 		this.nemesisAccount = this.addAccount(commonNisCache);
 		this.createNemesisAccounts(this.options.numAccounts(), commonNisCache);
@@ -75,7 +76,8 @@ public class BlockChainContext {
 			final MapperFactory mapperFactory = MapperUtils.createMapperFactory();
 			final NisMapperFactory nisMapperFactory = new NisMapperFactory(mapperFactory);
 			final BlockValidatorFactory blockValidatorFactory = NisUtils.createBlockValidatorFactory();
-			final BlockTransactionObserverFactory blockTransactionObserverFactory = new BlockTransactionObserverFactory(nisConfiguration.getForkConfiguration());
+			final BlockTransactionObserverFactory blockTransactionObserverFactory = new BlockTransactionObserverFactory(
+					nisConfiguration.getForkConfiguration());
 			final BlockChainServices services = Mockito.spy(new BlockChainServices(blockDao, blockTransactionObserverFactory,
 					blockValidatorFactory, transactionValidatorFactory, nisMapperFactory, nisConfiguration.getForkConfiguration()));
 			final BlockChainContextFactory contextFactory = Mockito

--- a/nis/src/test/java/org/nem/nis/test/BlockChain/BlockChainContext.java
+++ b/nis/src/test/java/org/nem/nis/test/BlockChain/BlockChainContext.java
@@ -50,7 +50,8 @@ public class BlockChainContext {
 		final ImportanceCalculator importanceCalculator = (blockHeight, accountStates) -> accountStates.stream()
 				.forEach(a -> a.getImportanceInfo().setImportance(blockHeight, 1.0 / accountStates.size()));
 		final DefaultPoxFacade poxFacade = new DefaultPoxFacade(importanceCalculator);
-		final ReadOnlyNisCache commonNisCache = NisCacheFactory.createReal(poxFacade);
+		final NisConfiguration nisConfiguration = new NisConfiguration();
+		final ReadOnlyNisCache commonNisCache = NisCacheFactory.createReal(poxFacade, nisConfiguration.getForkConfiguration().getMosaicRedefinitionForkHeight());
 		this.scorer = new BlockScorer(commonNisCache.getAccountStateCache());
 		this.nemesisAccount = this.addAccount(commonNisCache);
 		this.createNemesisAccounts(this.options.numAccounts(), commonNisCache);
@@ -58,7 +59,6 @@ public class BlockChainContext {
 		final List<Block> commonChain = this.createChain(nemesisBlock, this.options.commonChainHeight());
 		this.nodeContexts = new ArrayList<>();
 
-		final NisConfiguration nisConfiguration = new NisConfiguration();
 		for (int i = 0; i < this.options.numNodes(); i++) {
 			final Node node = this.createNode(i + 1);
 			final DefaultNisCache nisCache = Mockito.spy(((DefaultNisCache) commonNisCache).deepCopy());
@@ -75,7 +75,7 @@ public class BlockChainContext {
 			final MapperFactory mapperFactory = MapperUtils.createMapperFactory();
 			final NisMapperFactory nisMapperFactory = new NisMapperFactory(mapperFactory);
 			final BlockValidatorFactory blockValidatorFactory = NisUtils.createBlockValidatorFactory();
-			final BlockTransactionObserverFactory blockTransactionObserverFactory = new BlockTransactionObserverFactory();
+			final BlockTransactionObserverFactory blockTransactionObserverFactory = new BlockTransactionObserverFactory(nisConfiguration.getForkConfiguration());
 			final BlockChainServices services = Mockito.spy(new BlockChainServices(blockDao, blockTransactionObserverFactory,
 					blockValidatorFactory, transactionValidatorFactory, nisMapperFactory, nisConfiguration.getForkConfiguration()));
 			final BlockChainContextFactory contextFactory = Mockito

--- a/nis/src/test/java/org/nem/nis/test/MultisigTestContext.java
+++ b/nis/src/test/java/org/nem/nis/test/MultisigTestContext.java
@@ -16,8 +16,9 @@ import java.util.*;
 public class MultisigTestContext {
 	private final AccountStateCache accountStateCache = Mockito.mock(AccountStateCache.class);
 	private final AccountCache accountCache = Mockito.mock(AccountCache.class);
+	private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 	private final MultisigCosignatoryModificationValidator multisigCosignatoryModificationValidator = new MultisigCosignatoryModificationValidator(
-			this.accountStateCache);
+			this.accountStateCache, this.forkConfiguration.getmultisigMOfNForkHeight());
 	private final MultisigTransactionSignerValidator multisigTransactionSignerValidator = new MultisigTransactionSignerValidator(
 			this.accountStateCache);
 	private final MultisigSignaturesPresentValidator multisigSignaturesPresentValidator;
@@ -159,7 +160,7 @@ public class MultisigTestContext {
 	}
 
 	public ValidationResult validateNonOperational(final Transaction transaction) {
-		return validateNonOperational(BlockHeight.MAX, new ForkConfiguration(), transaction);
+		return validateNonOperational(BlockHeight.MAX, this.forkConfiguration, transaction);
 	}
 
 	public ValidationResult validateNonOperational(final BlockHeight height, final ForkConfiguration forkConfiguration,

--- a/nis/src/test/java/org/nem/nis/test/MultisigTestContext.java
+++ b/nis/src/test/java/org/nem/nis/test/MultisigTestContext.java
@@ -18,7 +18,7 @@ public class MultisigTestContext {
 	private final AccountCache accountCache = Mockito.mock(AccountCache.class);
 	private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 	private final MultisigCosignatoryModificationValidator multisigCosignatoryModificationValidator = new MultisigCosignatoryModificationValidator(
-			this.accountStateCache, this.forkConfiguration.getmultisigMOfNForkHeight());
+			this.accountStateCache, this.forkConfiguration.getMultisigMOfNForkHeight());
 	private final MultisigTransactionSignerValidator multisigTransactionSignerValidator = new MultisigTransactionSignerValidator(
 			this.accountStateCache);
 	private final MultisigSignaturesPresentValidator multisigSignaturesPresentValidator;

--- a/nis/src/test/java/org/nem/nis/test/NisCacheFactory.java
+++ b/nis/src/test/java/org/nem/nis/test/NisCacheFactory.java
@@ -1,6 +1,8 @@
 package org.nem.nis.test;
 
 import org.mockito.Mockito;
+import org.nem.core.model.primitive.BlockHeight;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 
 public class NisCacheFactory {
@@ -13,7 +15,8 @@ public class NisCacheFactory {
 	 * @return The NIS cache.
 	 */
 	public static ReadOnlyNisCache createReal() {
-		return createReal(new DefaultPoxFacade(NisUtils.createImportanceCalculator()));
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		return createReal(new DefaultPoxFacade(NisUtils.createImportanceCalculator()), forkConfiguration.getMosaicRedefinitionForkHeight());
 	}
 
 	/**
@@ -22,10 +25,10 @@ public class NisCacheFactory {
 	 * @param poxFacade The pox facade.
 	 * @return The NIS cache.
 	 */
-	public static ReadOnlyNisCache createReal(final DefaultPoxFacade poxFacade) {
+	public static ReadOnlyNisCache createReal(final DefaultPoxFacade poxFacade, final BlockHeight mosaicRedefinitionForkHeight) {
 		return new DefaultNisCache(new SynchronizedAccountCache(new DefaultAccountCache()),
 				new SynchronizedAccountStateCache(new DefaultAccountStateCache()), new SynchronizedPoxFacade(poxFacade),
-				new SynchronizedHashCache(new DefaultHashCache()), new SynchronizedNamespaceCache(new DefaultNamespaceCache()));
+				new SynchronizedHashCache(new DefaultHashCache()), new SynchronizedNamespaceCache(new DefaultNamespaceCache(mosaicRedefinitionForkHeight)));
 	}
 
 	// endregion

--- a/nis/src/test/java/org/nem/nis/test/NisCacheFactory.java
+++ b/nis/src/test/java/org/nem/nis/test/NisCacheFactory.java
@@ -28,7 +28,8 @@ public class NisCacheFactory {
 	public static ReadOnlyNisCache createReal(final DefaultPoxFacade poxFacade, final BlockHeight mosaicRedefinitionForkHeight) {
 		return new DefaultNisCache(new SynchronizedAccountCache(new DefaultAccountCache()),
 				new SynchronizedAccountStateCache(new DefaultAccountStateCache()), new SynchronizedPoxFacade(poxFacade),
-				new SynchronizedHashCache(new DefaultHashCache()), new SynchronizedNamespaceCache(new DefaultNamespaceCache(mosaicRedefinitionForkHeight)));
+				new SynchronizedHashCache(new DefaultHashCache()),
+				new SynchronizedNamespaceCache(new DefaultNamespaceCache(mosaicRedefinitionForkHeight)));
 	}
 
 	// endregion

--- a/nis/src/test/java/org/nem/nis/test/NisUtils.java
+++ b/nis/src/test/java/org/nem/nis/test/NisUtils.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
  */
 public class NisUtils {
 	private static final PoiOptions DEFAULT_POI_OPTIONS = new PoiOptionsBuilder().create();
+	private static final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 
 	/**
 	 * Creates a dummy DbBlock.
@@ -255,7 +256,7 @@ public class NisUtils {
 	 * @return The factory.
 	 */
 	public static TransactionValidatorFactory createTransactionValidatorFactory(final TimeProvider timeProvider) {
-		return new TransactionValidatorFactory(timeProvider, NetworkInfos.getDefault(), new ForkConfiguration(), false);
+		return new TransactionValidatorFactory(timeProvider, NetworkInfos.getDefault(), forkConfiguration, false);
 	}
 
 	/**
@@ -264,7 +265,7 @@ public class NisUtils {
 	 * @return The factory.
 	 */
 	public static BlockTransactionObserverFactory createBlockTransactionObserverFactory() {
-		return new BlockTransactionObserverFactory();
+		return new BlockTransactionObserverFactory(forkConfiguration);
 	}
 
 	/**
@@ -273,7 +274,7 @@ public class NisUtils {
 	 * @return The factory.
 	 */
 	public static BlockValidatorFactory createBlockValidatorFactory() {
-		return new BlockValidatorFactory(new SystemTimeProvider(), new ForkConfiguration());
+		return new BlockValidatorFactory(new SystemTimeProvider(), forkConfiguration);
 	}
 
 	/**

--- a/nis/src/test/java/org/nem/nis/test/UnconfirmedTransactionsTestUtils.java
+++ b/nis/src/test/java/org/nem/nis/test/UnconfirmedTransactionsTestUtils.java
@@ -44,7 +44,8 @@ public class UnconfirmedTransactionsTestUtils {
 			final TimeProvider timeProvider = Utils.createMockTimeProvider(CURRENT_TIME);
 			final UnconfirmedStateFactory factory = new UnconfirmedStateFactory(NisUtils.createTransactionValidatorFactory(timeProvider),
 					cache -> (notification, context) -> {
-					}, timeProvider, () -> new BlockHeight(511000), NisTestConstants.MAX_TRANSACTIONS_PER_BLOCK, new ForkConfiguration());
+					}, timeProvider, () -> new BlockHeight(511000), NisTestConstants.MAX_TRANSACTIONS_PER_BLOCK,
+					new ForkConfiguration.Builder().build());
 			this.transactions = creator.apply(factory, this.nisCache);
 		}
 

--- a/nis/src/test/java/org/nem/nis/validators/TransactionValidatorFactoryTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/TransactionValidatorFactoryTest.java
@@ -120,7 +120,6 @@ public class TransactionValidatorFactoryTest {
 
 	private static TransactionValidatorFactory createFactory() {
 		return new TransactionValidatorFactory(Mockito.mock(TimeProvider.class), NetworkInfos.getDefault(),
-				new ForkConfiguration.Builder().build(),
-				false);
+				new ForkConfiguration.Builder().build(), false);
 	}
 }

--- a/nis/src/test/java/org/nem/nis/validators/TransactionValidatorFactoryTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/TransactionValidatorFactoryTest.java
@@ -119,6 +119,8 @@ public class TransactionValidatorFactoryTest {
 	}
 
 	private static TransactionValidatorFactory createFactory() {
-		return new TransactionValidatorFactory(Mockito.mock(TimeProvider.class), NetworkInfos.getDefault(), new ForkConfiguration(), false);
+		return new TransactionValidatorFactory(Mockito.mock(TimeProvider.class), NetworkInfos.getDefault(),
+				new ForkConfiguration.Builder().build(),
+				false);
 	}
 }

--- a/nis/src/test/java/org/nem/nis/validators/block/TreasuryReissuanceForkTransactionBlockValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/block/TreasuryReissuanceForkTransactionBlockValidatorTest.java
@@ -32,7 +32,10 @@ public class TreasuryReissuanceForkTransactionBlockValidatorTest {
 		final List<Hash> hashes = generateRandomHashes(3);
 		final List<Hash> fallbackHashes = generateRandomHashes(4);
 
-		final ForkConfiguration forkConfiguration = new ForkConfiguration(new BlockHeight(1234), hashes, fallbackHashes);
+		final ForkConfiguration forkConfiguration =
+				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+						.treasuryReissuanceForkTransactionHashes(hashes)
+						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
 		final BlockValidator validator = new TreasuryReissuanceForkTransactionBlockValidator(forkConfiguration);
 
 		// Act:
@@ -52,7 +55,11 @@ public class TreasuryReissuanceForkTransactionBlockValidatorTest {
 		final List<Hash> hashes = generateRandomHashes(3);
 		final List<Hash> fallbackHashes = generateRandomHashes(4);
 
-		final ForkConfiguration forkConfiguration = new ForkConfiguration(new BlockHeight(1234), hashes, fallbackHashes);
+		final ForkConfiguration forkConfiguration =
+				new ForkConfiguration.Builder()
+						.treasuryReissuanceForkHeight(new BlockHeight(1234))
+						.treasuryReissuanceForkTransactionHashes(hashes)
+						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
 		final BlockValidator validator = new TreasuryReissuanceForkTransactionBlockValidator(forkConfiguration);
 
 		// Act:
@@ -77,7 +84,10 @@ public class TreasuryReissuanceForkTransactionBlockValidatorTest {
 
 		final List<Hash> fallbackHashes = generateRandomHashes(4);
 
-		final ForkConfiguration forkConfiguration = new ForkConfiguration(new BlockHeight(1234), hashes, fallbackHashes);
+		final ForkConfiguration forkConfiguration =
+				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+						.treasuryReissuanceForkTransactionHashes(hashes)
+						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
 		final BlockValidator validator = new TreasuryReissuanceForkTransactionBlockValidator(forkConfiguration);
 
 		// Act:
@@ -102,7 +112,10 @@ public class TreasuryReissuanceForkTransactionBlockValidatorTest {
 
 		final List<Hash> fallbackHashes = generateRandomHashes(4);
 
-		final ForkConfiguration forkConfiguration = new ForkConfiguration(new BlockHeight(1234), hashes, fallbackHashes);
+		final ForkConfiguration forkConfiguration =
+				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+						.treasuryReissuanceForkTransactionHashes(hashes)
+						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
 		final BlockValidator validator = new TreasuryReissuanceForkTransactionBlockValidator(forkConfiguration);
 
 		// Act:
@@ -127,7 +140,10 @@ public class TreasuryReissuanceForkTransactionBlockValidatorTest {
 		fallbackHashes.add(HashUtils.calculateHash(block.getTransactions().get(1)));
 		fallbackHashes.add(HashUtils.calculateHash(block.getTransactions().get(2)));
 
-		final ForkConfiguration forkConfiguration = new ForkConfiguration(new BlockHeight(1234), hashes, fallbackHashes);
+		final ForkConfiguration forkConfiguration =
+				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+						.treasuryReissuanceForkTransactionHashes(hashes)
+						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
 		final BlockValidator validator = new TreasuryReissuanceForkTransactionBlockValidator(forkConfiguration);
 
 		// Act:

--- a/nis/src/test/java/org/nem/nis/validators/block/TreasuryReissuanceForkTransactionBlockValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/block/TreasuryReissuanceForkTransactionBlockValidatorTest.java
@@ -32,10 +32,8 @@ public class TreasuryReissuanceForkTransactionBlockValidatorTest {
 		final List<Hash> hashes = generateRandomHashes(3);
 		final List<Hash> fallbackHashes = generateRandomHashes(4);
 
-		final ForkConfiguration forkConfiguration =
-				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
-						.treasuryReissuanceForkTransactionHashes(hashes)
-						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+				.treasuryReissuanceForkTransactionHashes(hashes).treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
 		final BlockValidator validator = new TreasuryReissuanceForkTransactionBlockValidator(forkConfiguration);
 
 		// Act:
@@ -55,11 +53,8 @@ public class TreasuryReissuanceForkTransactionBlockValidatorTest {
 		final List<Hash> hashes = generateRandomHashes(3);
 		final List<Hash> fallbackHashes = generateRandomHashes(4);
 
-		final ForkConfiguration forkConfiguration =
-				new ForkConfiguration.Builder()
-						.treasuryReissuanceForkHeight(new BlockHeight(1234))
-						.treasuryReissuanceForkTransactionHashes(hashes)
-						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+				.treasuryReissuanceForkTransactionHashes(hashes).treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
 		final BlockValidator validator = new TreasuryReissuanceForkTransactionBlockValidator(forkConfiguration);
 
 		// Act:
@@ -84,10 +79,8 @@ public class TreasuryReissuanceForkTransactionBlockValidatorTest {
 
 		final List<Hash> fallbackHashes = generateRandomHashes(4);
 
-		final ForkConfiguration forkConfiguration =
-				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
-						.treasuryReissuanceForkTransactionHashes(hashes)
-						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+				.treasuryReissuanceForkTransactionHashes(hashes).treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
 		final BlockValidator validator = new TreasuryReissuanceForkTransactionBlockValidator(forkConfiguration);
 
 		// Act:
@@ -112,10 +105,8 @@ public class TreasuryReissuanceForkTransactionBlockValidatorTest {
 
 		final List<Hash> fallbackHashes = generateRandomHashes(4);
 
-		final ForkConfiguration forkConfiguration =
-				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
-						.treasuryReissuanceForkTransactionHashes(hashes)
-						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+				.treasuryReissuanceForkTransactionHashes(hashes).treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
 		final BlockValidator validator = new TreasuryReissuanceForkTransactionBlockValidator(forkConfiguration);
 
 		// Act:
@@ -140,10 +131,8 @@ public class TreasuryReissuanceForkTransactionBlockValidatorTest {
 		fallbackHashes.add(HashUtils.calculateHash(block.getTransactions().get(1)));
 		fallbackHashes.add(HashUtils.calculateHash(block.getTransactions().get(2)));
 
-		final ForkConfiguration forkConfiguration =
-				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
-						.treasuryReissuanceForkTransactionHashes(hashes)
-						.treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+				.treasuryReissuanceForkTransactionHashes(hashes).treasuryReissuanceForkFallbackTransactionHashes(fallbackHashes).build();
 		final BlockValidator validator = new TreasuryReissuanceForkTransactionBlockValidator(forkConfiguration);
 
 		// Act:

--- a/nis/src/test/java/org/nem/nis/validators/integration/AbstractBlockChainValidatorTransactionValidationTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/integration/AbstractBlockChainValidatorTransactionValidationTest.java
@@ -152,7 +152,8 @@ public abstract class AbstractBlockChainValidatorTransactionValidationTest exten
 
 		public BlockChainValidator create(final NisCache nisCache) {
 			final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
-			final BlockTransactionObserver observer = new BlockTransactionObserverFactory(forkConfiguration).createExecuteCommitObserver(nisCache);
+			final BlockTransactionObserver observer = new BlockTransactionObserverFactory(forkConfiguration)
+					.createExecuteCommitObserver(nisCache);
 			return new BlockChainValidator(block -> new BlockExecuteProcessor(nisCache, block, observer), this.scorer, this.maxChainSize,
 					NisUtils.createBlockValidatorFactory().create(nisCache),
 					NisUtils.createTransactionValidatorFactory().createSingle(nisCache), NisCacheUtils.createValidationState(nisCache),

--- a/nis/src/test/java/org/nem/nis/validators/integration/AbstractBlockChainValidatorTransactionValidationTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/integration/AbstractBlockChainValidatorTransactionValidationTest.java
@@ -151,11 +151,12 @@ public abstract class AbstractBlockChainValidatorTransactionValidationTest exten
 		}
 
 		public BlockChainValidator create(final NisCache nisCache) {
-			final BlockTransactionObserver observer = new BlockTransactionObserverFactory().createExecuteCommitObserver(nisCache);
+			final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+			final BlockTransactionObserver observer = new BlockTransactionObserverFactory(forkConfiguration).createExecuteCommitObserver(nisCache);
 			return new BlockChainValidator(block -> new BlockExecuteProcessor(nisCache, block, observer), this.scorer, this.maxChainSize,
 					NisUtils.createBlockValidatorFactory().create(nisCache),
 					NisUtils.createTransactionValidatorFactory().createSingle(nisCache), NisCacheUtils.createValidationState(nisCache),
-					new ForkConfiguration());
+					forkConfiguration);
 		}
 	}
 }

--- a/nis/src/test/java/org/nem/nis/validators/integration/BlockChainServicesTransactionValidationTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/integration/BlockChainServicesTransactionValidationTest.java
@@ -22,12 +22,16 @@ public class BlockChainServicesTransactionValidationTest extends AbstractTransac
 	@Override
 	protected void assertTransactions(final BlockHeight chainHeight, final ReadOnlyNisCache nisCache, final List<Transaction> all,
 			final List<Transaction> expectedFiltered, final ValidationResult expectedResult) {
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+
 		while (true) {
 			// Arrange:
 			final BlockHeight parentHeight = chainHeight.prev(); // chainHeight is for block one (P -> [1] -> 2 -> 3)
+
 			final BlockChainServices blockChainServices = new BlockChainServices(Mockito.mock(BlockDao.class),
-					new BlockTransactionObserverFactory(), NisUtils.createBlockValidatorFactory(),
-					NisUtils.createTransactionValidatorFactory(), MapperUtils.createNisMapperFactory(), new ForkConfiguration());
+					new BlockTransactionObserverFactory(forkConfiguration), NisUtils.createBlockValidatorFactory(),
+					NisUtils.createTransactionValidatorFactory(), MapperUtils.createNisMapperFactory(),
+					forkConfiguration);
 
 			final NisCache copyCache = nisCache.copy();
 			final Account blockSigner = createBlockSigner(copyCache, parentHeight);

--- a/nis/src/test/java/org/nem/nis/validators/integration/BlockChainServicesTransactionValidationTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/integration/BlockChainServicesTransactionValidationTest.java
@@ -30,8 +30,7 @@ public class BlockChainServicesTransactionValidationTest extends AbstractTransac
 
 			final BlockChainServices blockChainServices = new BlockChainServices(Mockito.mock(BlockDao.class),
 					new BlockTransactionObserverFactory(forkConfiguration), NisUtils.createBlockValidatorFactory(),
-					NisUtils.createTransactionValidatorFactory(), MapperUtils.createNisMapperFactory(),
-					forkConfiguration);
+					NisUtils.createTransactionValidatorFactory(), MapperUtils.createNisMapperFactory(), forkConfiguration);
 
 			final NisCache copyCache = nisCache.copy();
 			final Account blockSigner = createBlockSigner(copyCache, parentHeight);

--- a/nis/src/test/java/org/nem/nis/validators/integration/DefaultNewBlockTransactionsProviderTransactionValidationTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/integration/DefaultNewBlockTransactionsProviderTransactionValidationTest.java
@@ -35,16 +35,17 @@ public class DefaultNewBlockTransactionsProviderTransactionValidationTest extend
 
 		private TestContext(final BlockHeight chainHeight, final ReadOnlyNisCache nisCache) {
 			final int maxTransactionsPerBlock = NisTestConstants.MAX_TRANSACTIONS_PER_BLOCK;
+			final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 			final UnconfirmedStateFactory unconfirmedStateFactory = new UnconfirmedStateFactory(
 					NisUtils.createTransactionValidatorFactory(),
 					NisUtils.createBlockTransactionObserverFactory()::createExecuteCommitObserver,
 					Utils.createMockTimeProvider(CURRENT_TIME.getRawTime()), () -> chainHeight, maxTransactionsPerBlock,
-					new ForkConfiguration());
+					forkConfiguration);
 			this.transactions = new DefaultUnconfirmedTransactions(unconfirmedStateFactory, nisCache);
 
 			this.provider = new DefaultNewBlockTransactionsProvider(nisCache, NisUtils.createTransactionValidatorFactory(),
-					NisUtils.createBlockValidatorFactory(), new BlockTransactionObserverFactory(), this.transactions.asFilter(),
-					new ForkConfiguration());
+					NisUtils.createBlockValidatorFactory(), new BlockTransactionObserverFactory(forkConfiguration), this.transactions.asFilter(),
+					forkConfiguration);
 		}
 
 		public List<Transaction> getBlockTransactions() {

--- a/nis/src/test/java/org/nem/nis/validators/integration/DefaultNewBlockTransactionsProviderTransactionValidationTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/integration/DefaultNewBlockTransactionsProviderTransactionValidationTest.java
@@ -39,13 +39,12 @@ public class DefaultNewBlockTransactionsProviderTransactionValidationTest extend
 			final UnconfirmedStateFactory unconfirmedStateFactory = new UnconfirmedStateFactory(
 					NisUtils.createTransactionValidatorFactory(),
 					NisUtils.createBlockTransactionObserverFactory()::createExecuteCommitObserver,
-					Utils.createMockTimeProvider(CURRENT_TIME.getRawTime()), () -> chainHeight, maxTransactionsPerBlock,
-					forkConfiguration);
+					Utils.createMockTimeProvider(CURRENT_TIME.getRawTime()), () -> chainHeight, maxTransactionsPerBlock, forkConfiguration);
 			this.transactions = new DefaultUnconfirmedTransactions(unconfirmedStateFactory, nisCache);
 
 			this.provider = new DefaultNewBlockTransactionsProvider(nisCache, NisUtils.createTransactionValidatorFactory(),
-					NisUtils.createBlockValidatorFactory(), new BlockTransactionObserverFactory(forkConfiguration), this.transactions.asFilter(),
-					forkConfiguration);
+					NisUtils.createBlockValidatorFactory(), new BlockTransactionObserverFactory(forkConfiguration),
+					this.transactions.asFilter(), forkConfiguration);
 		}
 
 		public List<Transaction> getBlockTransactions() {

--- a/nis/src/test/java/org/nem/nis/validators/integration/UnconfirmedTransactionsTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/integration/UnconfirmedTransactionsTransactionValidatorTest.java
@@ -21,7 +21,7 @@ public class UnconfirmedTransactionsTransactionValidatorTest extends AbstractTra
 		final UnconfirmedStateFactory unconfirmedStateFactory = new UnconfirmedStateFactory(NisUtils.createTransactionValidatorFactory(),
 				NisUtils.createBlockTransactionObserverFactory()::createExecuteCommitObserver,
 				Utils.createMockTimeProvider(CURRENT_TIME.getRawTime()), () -> chainHeight, NisTestConstants.MAX_TRANSACTIONS_PER_BLOCK,
-				new ForkConfiguration());
+				new ForkConfiguration.Builder().build());
 		final UnconfirmedTransactions transactions = new DefaultUnconfirmedTransactions(unconfirmedStateFactory, nisCache);
 
 		expectedFiltered = new ArrayList<>(expectedFiltered);

--- a/nis/src/test/java/org/nem/nis/validators/transaction/FeeSinkNonOperationalValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/FeeSinkNonOperationalValidatorTest.java
@@ -19,7 +19,8 @@ public class FeeSinkNonOperationalValidatorTest {
 		final MultisigTestContext context = new MultisigTestContext(multisigAccount);
 		final MultisigTransaction transaction = context.createMultisigTransferTransaction();
 
-		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234)).build();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234))
+				.build();
 		final FeeSinkNonOperationalValidator validator = new FeeSinkNonOperationalValidator(forkConfiguration);
 
 		// Act:

--- a/nis/src/test/java/org/nem/nis/validators/transaction/FeeSinkNonOperationalValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/FeeSinkNonOperationalValidatorTest.java
@@ -3,7 +3,6 @@ package org.nem.nis.validators.transaction;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.*;
-import org.nem.core.crypto.*;
 import org.nem.core.model.*;
 import org.nem.core.model.mosaic.MosaicConstants;
 import org.nem.core.model.primitive.BlockHeight;
@@ -11,8 +10,6 @@ import org.nem.core.test.*;
 import org.nem.nis.test.*;
 import org.nem.nis.validators.*;
 import org.nem.nis.ForkConfiguration;
-
-import java.util.*;
 
 public class FeeSinkNonOperationalValidatorTest {
 
@@ -22,8 +19,7 @@ public class FeeSinkNonOperationalValidatorTest {
 		final MultisigTestContext context = new MultisigTestContext(multisigAccount);
 		final MultisigTransaction transaction = context.createMultisigTransferTransaction();
 
-		final ForkConfiguration forkConfiguration = new ForkConfiguration(new BlockHeight(1234), new ArrayList<Hash>(),
-				new ArrayList<Hash>());
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(1234)).build();
 		final FeeSinkNonOperationalValidator validator = new FeeSinkNonOperationalValidator(forkConfiguration);
 
 		// Act:

--- a/nis/src/test/java/org/nem/nis/validators/transaction/ImportanceTransferTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/ImportanceTransferTransactionValidatorTest.java
@@ -420,7 +420,8 @@ public class ImportanceTransferTransactionValidatorTest {
 
 		private void addNamespaceOwner(final Account account, final NamespaceId id) {
 			final Namespace namespace = new Namespace(id, account, new BlockHeight(123));
-			final NamespaceEntry entry = new NamespaceEntry(namespace, new Mosaics(id, this.forkConfiguration.getMosaicRedefinitionForkHeight()));
+			final NamespaceEntry entry = new NamespaceEntry(namespace,
+					new Mosaics(id, this.forkConfiguration.getMosaicRedefinitionForkHeight()));
 			Mockito.when(this.namespaceCache.getRootNamespaceIds()).thenReturn(Collections.singletonList(id));
 			Mockito.when(this.namespaceCache.get(id)).thenReturn(entry);
 		}

--- a/nis/src/test/java/org/nem/nis/validators/transaction/ImportanceTransferTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/ImportanceTransferTransactionValidatorTest.java
@@ -10,6 +10,7 @@ import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
 import org.nem.core.time.TimeInstant;
 import org.nem.nis.BlockMarkerConstants;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.state.*;
 import org.nem.nis.test.*;
@@ -383,8 +384,9 @@ public class ImportanceTransferTransactionValidatorTest {
 	private static class TestContext {
 		private final AccountStateCache accountStateCache = Mockito.mock(AccountStateCache.class);
 		private final NamespaceCache namespaceCache = Mockito.mock(NamespaceCache.class);
+		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		private final ImportanceTransferTransactionValidator validator = new ImportanceTransferTransactionValidator(this.accountStateCache,
-				this.namespaceCache);
+				this.namespaceCache, this.forkConfiguration.getRemoteAccountForkHeight());
 
 		private ImportanceTransferTransaction createTransaction(final ImportanceTransferMode mode) {
 			final Account signer = Utils.generateRandomAccount();
@@ -418,7 +420,7 @@ public class ImportanceTransferTransactionValidatorTest {
 
 		private void addNamespaceOwner(final Account account, final NamespaceId id) {
 			final Namespace namespace = new Namespace(id, account, new BlockHeight(123));
-			final NamespaceEntry entry = new NamespaceEntry(namespace, new Mosaics(id));
+			final NamespaceEntry entry = new NamespaceEntry(namespace, new Mosaics(id, this.forkConfiguration.getMosaicRedefinitionForkHeight()));
 			Mockito.when(this.namespaceCache.getRootNamespaceIds()).thenReturn(Collections.singletonList(id));
 			Mockito.when(this.namespaceCache.get(id)).thenReturn(entry);
 		}

--- a/nis/src/test/java/org/nem/nis/validators/transaction/MinimumFeeValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/MinimumFeeValidatorTest.java
@@ -52,8 +52,7 @@ public class MinimumFeeValidatorTest {
 		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		final Address signerAddress = isSignerNemesisAccount ? transaction.getSigner().getAddress() : Utils.generateRandomAddress();
 		final SingleTransactionValidator validator = new MinimumFeeValidator(createNetworkInfo(signerAddress),
-				new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()), false, forkConfiguration.getFeeForkHeight(),
-				forkConfiguration.getSecondFeeForkHeight());
+				new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()), false, forkConfiguration.getFeeFork());
 
 		// Act:
 		final ValidationResult result = validator.validate(transaction,
@@ -92,7 +91,7 @@ public class MinimumFeeValidatorTest {
 		transaction.setDeadline(new TimeInstant(1));
 
 		final SingleTransactionValidator validator = new MinimumFeeValidator(createNetworkInfo(Utils.generateRandomAddress()),
-				namespaceCache, false, forkConfiguration.getFeeForkHeight(), forkConfiguration.getSecondFeeForkHeight());
+				namespaceCache, false, forkConfiguration.getFeeFork());
 
 		// Act:
 		final ValidationResult result = validator.validate(transaction,
@@ -116,8 +115,7 @@ public class MinimumFeeValidatorTest {
 		// Arrange:
 		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		final SingleTransactionValidator validator = new MinimumFeeValidator(createNetworkInfo(Utils.generateRandomAddress()),
-				new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()), true, forkConfiguration.getFeeForkHeight(),
-				forkConfiguration.getSecondFeeForkHeight());
+				new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()), true, forkConfiguration.getFeeFork());
 		final Collection<Transaction> transactions = TestTransactionRegistry.stream().map(entry -> {
 			final Transaction transaction = entry.createModel.get();
 			transaction.setFee(fee);

--- a/nis/src/test/java/org/nem/nis/validators/transaction/MinimumFeeValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/MinimumFeeValidatorTest.java
@@ -52,8 +52,8 @@ public class MinimumFeeValidatorTest {
 		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		final Address signerAddress = isSignerNemesisAccount ? transaction.getSigner().getAddress() : Utils.generateRandomAddress();
 		final SingleTransactionValidator validator = new MinimumFeeValidator(createNetworkInfo(signerAddress),
-				new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()),
-				false, forkConfiguration.getFeeForkHeight(), forkConfiguration.getSecondFeeForkHeight());
+				new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()), false, forkConfiguration.getFeeForkHeight(),
+				forkConfiguration.getSecondFeeForkHeight());
 
 		// Act:
 		final ValidationResult result = validator.validate(transaction,
@@ -116,8 +116,8 @@ public class MinimumFeeValidatorTest {
 		// Arrange:
 		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		final SingleTransactionValidator validator = new MinimumFeeValidator(createNetworkInfo(Utils.generateRandomAddress()),
-				new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()), true,
-				forkConfiguration.getFeeForkHeight(), forkConfiguration.getSecondFeeForkHeight());
+				new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()), true, forkConfiguration.getFeeForkHeight(),
+				forkConfiguration.getSecondFeeForkHeight());
 		final Collection<Transaction> transactions = TestTransactionRegistry.stream().map(entry -> {
 			final Transaction transaction = entry.createModel.get();
 			transaction.setFee(fee);

--- a/nis/src/test/java/org/nem/nis/validators/transaction/MosaicBagValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/MosaicBagValidatorTest.java
@@ -9,6 +9,7 @@ import org.nem.core.model.namespace.Namespace;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
 import org.nem.core.time.TimeInstant;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.state.MosaicEntry;
 import org.nem.nis.test.ValidationStates;
@@ -219,7 +220,8 @@ public class MosaicBagValidatorTest {
 	private static class TestContext {
 		private final Account signer = Utils.generateRandomAccount();
 		private final Account recipient = Utils.generateRandomAccount();
-		private final NamespaceCache namespaceCache = new DefaultNamespaceCache().copy();
+		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		private final NamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 		private final MosaicBagValidator validator = new MosaicBagValidator(this.namespaceCache);
 
 		public void addMosaicDefinition(final MosaicDefinition mosaicDefinition) {

--- a/nis/src/test/java/org/nem/nis/validators/transaction/MosaicDefinitionCreationTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/MosaicDefinitionCreationTransactionValidatorTest.java
@@ -582,8 +582,8 @@ public class MosaicDefinitionCreationTransactionValidatorTest {
 	private static class TestContext {
 		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		final NamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
-		final MosaicDefinitionCreationTransactionValidator validator = new MosaicDefinitionCreationTransactionValidator(
-				this.namespaceCache, forkConfiguration.getFeeForkHeight(), forkConfiguration.getSecondFeeForkHeight());
+		final MosaicDefinitionCreationTransactionValidator validator = new MosaicDefinitionCreationTransactionValidator(this.namespaceCache,
+				forkConfiguration.getFeeForkHeight(), forkConfiguration.getSecondFeeForkHeight());
 
 		public void activateNamespaceAtHeight(final Account signer, final BlockHeight height) {
 			for (final String namespace : Arrays.asList("alice", "alice.vouchers")) {

--- a/nis/src/test/java/org/nem/nis/validators/transaction/MosaicDefinitionCreationTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/MosaicDefinitionCreationTransactionValidatorTest.java
@@ -583,7 +583,7 @@ public class MosaicDefinitionCreationTransactionValidatorTest {
 		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		final NamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 		final MosaicDefinitionCreationTransactionValidator validator = new MosaicDefinitionCreationTransactionValidator(this.namespaceCache,
-				forkConfiguration.getFeeForkHeight(), forkConfiguration.getSecondFeeForkHeight());
+				forkConfiguration.getFeeFork());
 
 		public void activateNamespaceAtHeight(final Account signer, final BlockHeight height) {
 			for (final String namespace : Arrays.asList("alice", "alice.vouchers")) {

--- a/nis/src/test/java/org/nem/nis/validators/transaction/MosaicDefinitionCreationTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/MosaicDefinitionCreationTransactionValidatorTest.java
@@ -10,6 +10,7 @@ import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
 import org.nem.core.time.TimeInstant;
 import org.nem.nis.BlockMarkerConstants;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.state.MosaicEntry;
 import org.nem.nis.test.ValidationStates;
@@ -579,9 +580,10 @@ public class MosaicDefinitionCreationTransactionValidatorTest {
 	}
 
 	private static class TestContext {
-		final NamespaceCache namespaceCache = new DefaultNamespaceCache().copy();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		final NamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 		final MosaicDefinitionCreationTransactionValidator validator = new MosaicDefinitionCreationTransactionValidator(
-				this.namespaceCache);
+				this.namespaceCache, forkConfiguration.getFeeForkHeight(), forkConfiguration.getSecondFeeForkHeight());
 
 		public void activateNamespaceAtHeight(final Account signer, final BlockHeight height) {
 			for (final String namespace : Arrays.asList("alice", "alice.vouchers")) {

--- a/nis/src/test/java/org/nem/nis/validators/transaction/MosaicSupplyChangeTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/MosaicSupplyChangeTransactionValidatorTest.java
@@ -9,6 +9,7 @@ import org.nem.core.model.namespace.Namespace;
 import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
 import org.nem.core.time.TimeInstant;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.state.MosaicEntry;
 import org.nem.nis.test.ValidationStates;
@@ -227,7 +228,8 @@ public class MosaicSupplyChangeTransactionValidatorTest {
 
 	private static class TestContext {
 		private final Account signer = Utils.generateRandomAccount();
-		private final NamespaceCache namespaceCache = new DefaultNamespaceCache().copy();
+		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		private final NamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 		private final MosaicSupplyChangeTransactionValidator validator = new MosaicSupplyChangeTransactionValidator(this.namespaceCache);
 
 		public void addMosaicDefinition(final MosaicDefinition mosaicDefinition) {

--- a/nis/src/test/java/org/nem/nis/validators/transaction/MultisigNonOperationalValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/MultisigNonOperationalValidatorTest.java
@@ -111,7 +111,9 @@ public class MultisigNonOperationalValidatorTest {
 
 		final ArrayList<Hash> transactionHashes = new ArrayList<Hash>();
 		transactionHashes.add(HashUtils.calculateHash(transaction));
-		final ForkConfiguration forkConfiguration = new ForkConfiguration(new BlockHeight(12345), transactionHashes, new ArrayList<Hash>());
+		final ForkConfiguration forkConfiguration =
+				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(12345))
+						.treasuryReissuanceForkTransactionHashes(transactionHashes).build();
 
 		// Act:
 		final ValidationResult result = context.validateNonOperational(new BlockHeight(12345), forkConfiguration, transaction);
@@ -129,7 +131,9 @@ public class MultisigNonOperationalValidatorTest {
 
 		final ArrayList<Hash> transactionHashes = new ArrayList<Hash>();
 		transactionHashes.add(HashUtils.calculateHash(transaction));
-		final ForkConfiguration forkConfiguration = new ForkConfiguration(new BlockHeight(12345), transactionHashes, new ArrayList<Hash>());
+		final ForkConfiguration forkConfiguration =
+				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(12345))
+						.treasuryReissuanceForkTransactionHashes(transactionHashes).build();
 
 		// Act:
 		final ValidationResult result = context.validateNonOperational(new BlockHeight(12346), forkConfiguration, transaction);
@@ -147,7 +151,9 @@ public class MultisigNonOperationalValidatorTest {
 
 		final ArrayList<Hash> transactionHashes = new ArrayList<Hash>();
 		transactionHashes.add(HashUtils.calculateHash(transaction));
-		final ForkConfiguration forkConfiguration = new ForkConfiguration(new BlockHeight(12345), new ArrayList<Hash>(), transactionHashes);
+		final ForkConfiguration forkConfiguration =
+				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(12345))
+						.treasuryReissuanceForkFallbackTransactionHashes(transactionHashes).build();
 
 		// Act:
 		final ValidationResult result = context.validateNonOperational(new BlockHeight(12345), forkConfiguration, transaction);

--- a/nis/src/test/java/org/nem/nis/validators/transaction/MultisigNonOperationalValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/MultisigNonOperationalValidatorTest.java
@@ -111,9 +111,8 @@ public class MultisigNonOperationalValidatorTest {
 
 		final ArrayList<Hash> transactionHashes = new ArrayList<Hash>();
 		transactionHashes.add(HashUtils.calculateHash(transaction));
-		final ForkConfiguration forkConfiguration =
-				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(12345))
-						.treasuryReissuanceForkTransactionHashes(transactionHashes).build();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(12345))
+				.treasuryReissuanceForkTransactionHashes(transactionHashes).build();
 
 		// Act:
 		final ValidationResult result = context.validateNonOperational(new BlockHeight(12345), forkConfiguration, transaction);
@@ -131,9 +130,8 @@ public class MultisigNonOperationalValidatorTest {
 
 		final ArrayList<Hash> transactionHashes = new ArrayList<Hash>();
 		transactionHashes.add(HashUtils.calculateHash(transaction));
-		final ForkConfiguration forkConfiguration =
-				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(12345))
-						.treasuryReissuanceForkTransactionHashes(transactionHashes).build();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(12345))
+				.treasuryReissuanceForkTransactionHashes(transactionHashes).build();
 
 		// Act:
 		final ValidationResult result = context.validateNonOperational(new BlockHeight(12346), forkConfiguration, transaction);
@@ -151,9 +149,8 @@ public class MultisigNonOperationalValidatorTest {
 
 		final ArrayList<Hash> transactionHashes = new ArrayList<Hash>();
 		transactionHashes.add(HashUtils.calculateHash(transaction));
-		final ForkConfiguration forkConfiguration =
-				new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(12345))
-						.treasuryReissuanceForkFallbackTransactionHashes(transactionHashes).build();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().treasuryReissuanceForkHeight(new BlockHeight(12345))
+				.treasuryReissuanceForkFallbackTransactionHashes(transactionHashes).build();
 
 		// Act:
 		final ValidationResult result = context.validateNonOperational(new BlockHeight(12345), forkConfiguration, transaction);

--- a/nis/src/test/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidatorTest.java
@@ -645,7 +645,7 @@ public class ProvisionNamespaceTransactionValidatorTest {
 		private final NamespaceCache namespaceCache = new DefaultNamespaceCache(this.forkConfiguration.getMosaicRedefinitionForkHeight())
 				.copy();
 		private final TSingleTransactionValidator<ProvisionNamespaceTransaction> validator = new ProvisionNamespaceTransactionValidator(
-				this.namespaceCache, this.forkConfiguration.getFeeForkHeight(), this.forkConfiguration.getSecondFeeForkHeight());
+				this.namespaceCache, this.forkConfiguration.getFeeFork());
 
 		private TestContext(final String parent, final String part) {
 			this(parent, part, new BlockHeight(50),

--- a/nis/src/test/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidatorTest.java
@@ -10,6 +10,7 @@ import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
 import org.nem.core.time.TimeInstant;
 import org.nem.nis.BlockMarkerConstants;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.test.*;
 import org.nem.nis.validators.ValidationContext;
@@ -640,9 +641,13 @@ public class ProvisionNamespaceTransactionValidatorTest {
 		private final NamespaceId parent;
 		private final Namespace parentNamespace;
 		private final NamespaceIdPart part;
-		private final NamespaceCache namespaceCache = new DefaultNamespaceCache().copy();
+		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		private final NamespaceCache namespaceCache =
+				new DefaultNamespaceCache(this.forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
 		private final TSingleTransactionValidator<ProvisionNamespaceTransaction> validator = new ProvisionNamespaceTransactionValidator(
-				this.namespaceCache);
+				this.namespaceCache,
+				this.forkConfiguration.getFeeForkHeight(),
+				this.forkConfiguration.getSecondFeeForkHeight());
 
 		private TestContext(final String parent, final String part) {
 			this(parent, part, new BlockHeight(50),

--- a/nis/src/test/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/ProvisionNamespaceTransactionValidatorTest.java
@@ -642,12 +642,10 @@ public class ProvisionNamespaceTransactionValidatorTest {
 		private final Namespace parentNamespace;
 		private final NamespaceIdPart part;
 		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
-		private final NamespaceCache namespaceCache =
-				new DefaultNamespaceCache(this.forkConfiguration.getMosaicRedefinitionForkHeight()).copy();
+		private final NamespaceCache namespaceCache = new DefaultNamespaceCache(this.forkConfiguration.getMosaicRedefinitionForkHeight())
+				.copy();
 		private final TSingleTransactionValidator<ProvisionNamespaceTransaction> validator = new ProvisionNamespaceTransactionValidator(
-				this.namespaceCache,
-				this.forkConfiguration.getFeeForkHeight(),
-				this.forkConfiguration.getSecondFeeForkHeight());
+				this.namespaceCache, this.forkConfiguration.getFeeForkHeight(), this.forkConfiguration.getSecondFeeForkHeight());
 
 		private TestContext(final String parent, final String part) {
 			this(parent, part, new BlockHeight(50),

--- a/nis/src/test/java/org/nem/nis/validators/transaction/RemoteNonOperationalValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/RemoteNonOperationalValidatorTest.java
@@ -244,7 +244,8 @@ public class RemoteNonOperationalValidatorTest {
 		public void assertValidationResult(final Transaction transaction, final BlockHeight height, final ValidationResult expectedResult) {
 			// Arrange:
 			final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
-			final SingleTransactionValidator validator = new RemoteNonOperationalValidator(this.accountStateCache, forkConfiguration.getMosaicRedefinitionForkHeight());
+			final SingleTransactionValidator validator = new RemoteNonOperationalValidator(this.accountStateCache,
+					forkConfiguration.getMosaicRedefinitionForkHeight());
 
 			// Act:
 			final ValidationResult result = validator.validate(transaction, new ValidationContext(height, ValidationStates.Throw));

--- a/nis/src/test/java/org/nem/nis/validators/transaction/RemoteNonOperationalValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/RemoteNonOperationalValidatorTest.java
@@ -11,6 +11,7 @@ import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
 import org.nem.core.time.TimeInstant;
 import org.nem.nis.BlockMarkerConstants;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.cache.*;
 import org.nem.nis.state.*;
 import org.nem.nis.test.ValidationStates;
@@ -242,7 +243,8 @@ public class RemoteNonOperationalValidatorTest {
 
 		public void assertValidationResult(final Transaction transaction, final BlockHeight height, final ValidationResult expectedResult) {
 			// Arrange:
-			final SingleTransactionValidator validator = new RemoteNonOperationalValidator(this.accountStateCache);
+			final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+			final SingleTransactionValidator validator = new RemoteNonOperationalValidator(this.accountStateCache, forkConfiguration.getMosaicRedefinitionForkHeight());
 
 			// Act:
 			final ValidationResult result = validator.validate(transaction, new ValidationContext(height, ValidationStates.Throw));

--- a/nis/src/test/java/org/nem/nis/validators/transaction/TSingleTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/TSingleTransactionValidatorTest.java
@@ -3,13 +3,16 @@ package org.nem.nis.validators.transaction;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.*;
+import org.nem.nis.ForkConfiguration;
 
 public class TSingleTransactionValidatorTest {
 
 	@Test
 	public void defaultGetNameReturnsTypeName() {
 		// Arrange:
-		final TSingleTransactionValidator<?> validator = new TransferTransactionValidator();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		final TSingleTransactionValidator<?> validator = new TransferTransactionValidator(forkConfiguration.getRemoteAccountForkHeight(),
+				forkConfiguration.getmultisigMOfNForkHeight());
 
 		// Act:
 		final String name = validator.getName();

--- a/nis/src/test/java/org/nem/nis/validators/transaction/TSingleTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/TSingleTransactionValidatorTest.java
@@ -12,7 +12,7 @@ public class TSingleTransactionValidatorTest {
 		// Arrange:
 		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		final TSingleTransactionValidator<?> validator = new TransferTransactionValidator(forkConfiguration.getRemoteAccountForkHeight(),
-				forkConfiguration.getmultisigMOfNForkHeight());
+				forkConfiguration.getMultisigMOfNForkHeight());
 
 		// Act:
 		final String name = validator.getName();

--- a/nis/src/test/java/org/nem/nis/validators/transaction/TransferTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/TransferTransactionValidatorTest.java
@@ -15,9 +15,8 @@ import org.nem.nis.validators.ValidationContext;
 
 public class TransferTransactionValidatorTest {
 	private static final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
-	private static final TSingleTransactionValidator<TransferTransaction> VALIDATOR =
-			new TransferTransactionValidator(forkConfiguration.getRemoteAccountForkHeight(),
-					forkConfiguration.getmultisigMOfNForkHeight());
+	private static final TSingleTransactionValidator<TransferTransaction> VALIDATOR = new TransferTransactionValidator(
+			forkConfiguration.getRemoteAccountForkHeight(), forkConfiguration.getmultisigMOfNForkHeight());
 	private static final int ORIGINAL_MAX_MESSAGE_SIZE = 96;
 	private static final int MAX_MESSAGE_SIZE_MULTISIG_FORK = 160;
 	private static final int CURRENT_MAX_MESSAGE_SIZE = 1024;

--- a/nis/src/test/java/org/nem/nis/validators/transaction/TransferTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/TransferTransactionValidatorTest.java
@@ -9,11 +9,15 @@ import org.nem.core.model.primitive.*;
 import org.nem.core.test.Utils;
 import org.nem.core.time.TimeInstant;
 import org.nem.nis.BlockMarkerConstants;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.test.ValidationStates;
 import org.nem.nis.validators.ValidationContext;
 
 public class TransferTransactionValidatorTest {
-	private static final TSingleTransactionValidator<TransferTransaction> VALIDATOR = new TransferTransactionValidator();
+	private static final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+	private static final TSingleTransactionValidator<TransferTransaction> VALIDATOR =
+			new TransferTransactionValidator(forkConfiguration.getRemoteAccountForkHeight(),
+					forkConfiguration.getmultisigMOfNForkHeight());
 	private static final int ORIGINAL_MAX_MESSAGE_SIZE = 96;
 	private static final int MAX_MESSAGE_SIZE_MULTISIG_FORK = 160;
 	private static final int CURRENT_MAX_MESSAGE_SIZE = 1024;

--- a/nis/src/test/java/org/nem/nis/validators/transaction/TransferTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/TransferTransactionValidatorTest.java
@@ -16,7 +16,7 @@ import org.nem.nis.validators.ValidationContext;
 public class TransferTransactionValidatorTest {
 	private static final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 	private static final TSingleTransactionValidator<TransferTransaction> VALIDATOR = new TransferTransactionValidator(
-			forkConfiguration.getRemoteAccountForkHeight(), forkConfiguration.getmultisigMOfNForkHeight());
+			forkConfiguration.getRemoteAccountForkHeight(), forkConfiguration.getMultisigMOfNForkHeight());
 	private static final int ORIGINAL_MAX_MESSAGE_SIZE = 96;
 	private static final int MAX_MESSAGE_SIZE_MULTISIG_FORK = 160;
 	private static final int CURRENT_MAX_MESSAGE_SIZE = 1024;

--- a/nis/src/test/java/org/nem/nis/validators/transaction/VersionTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/VersionTransactionValidatorTest.java
@@ -12,6 +12,7 @@ import org.nem.core.model.primitive.BlockHeight;
 import org.nem.core.serialization.JsonSerializer;
 import org.nem.core.test.*;
 import org.nem.nis.BlockMarkerConstants;
+import org.nem.nis.ForkConfiguration;
 import org.nem.nis.test.ValidationStates;
 import org.nem.nis.validators.*;
 
@@ -178,7 +179,9 @@ public class VersionTransactionValidatorTest {
 
 	private static void assertValidation(final Transaction transaction, final long blockHeight, final ValidationResult expectedResult) {
 		// Arrange:
-		final SingleTransactionValidator validator = new VersionTransactionValidator();
+		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
+		final SingleTransactionValidator validator = new VersionTransactionValidator(forkConfiguration.getMosaicsForkHeight(),
+				forkConfiguration.getmultisigMOfNForkHeight());
 		final ValidationContext validationContext = new ValidationContext(new BlockHeight(blockHeight), ValidationStates.Throw);
 
 		// Act:

--- a/nis/src/test/java/org/nem/nis/validators/transaction/VersionTransactionValidatorTest.java
+++ b/nis/src/test/java/org/nem/nis/validators/transaction/VersionTransactionValidatorTest.java
@@ -181,7 +181,7 @@ public class VersionTransactionValidatorTest {
 		// Arrange:
 		final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		final SingleTransactionValidator validator = new VersionTransactionValidator(forkConfiguration.getMosaicsForkHeight(),
-				forkConfiguration.getmultisigMOfNForkHeight());
+				forkConfiguration.getMultisigMOfNForkHeight());
 		final ValidationContext validationContext = new ValidationContext(new BlockHeight(blockHeight), ValidationStates.Throw);
 
 		// Act:


### PR DESCRIPTION
problem: new testnet does not work with NEM wallet
solution: allow the fork heights to be override from the nis configuration.
               setting the fork height to 1 for all forks will create a testnet
                with the same functionally as mainnet

This is the initial PR for the fork changes.  
1. extend the current ForkConfiguration class to include all fork info
2. plump the ForkConfiguration class the all the fork location
3. default fork height is left unchanged.
4. fork height can be overridden in the nis configuration file
 
Ran a test with the NEM Wallet and was able to submit a transfer tx at block 3 when all the fork height is set to 1.  Feedback welcome but still need to run some more tests.
![Screenshot from 2023-03-10 01-10-57](https://user-images.githubusercontent.com/44558938/224241251-1eb84bf8-db19-4c34-a4ab-73c9a46ceaa6.png)
