### PR TITLE
[core] fix: increase the delay on api request

### DIFF
--- a/core/src/test/java/org/nem/core/connect/HttpMethodClientTest.java
+++ b/core/src/test/java/org/nem/core/connect/HttpMethodClientTest.java
@@ -153,7 +153,7 @@ public class HttpMethodClientTest {
 			this.runTestWithTimeoutService((mockService, requestUrl) -> {
 				// Arrange:
 				// - set a delay in request processing to simulate a socket timeout
-				mockService.addRequestProcessingDelay(1000);
+				mockService.addRequestProcessingDelay(10000);
 				final HttpMethodClient<Deserializer> client = new HttpMethodClient<>(GOOD_TIMEOUT, 500, GOOD_TIMEOUT);
 
 				// Act:


### PR DESCRIPTION
problem: mock request is returning data instead of timing out
solution: increase the delay on the mock object to return data