### PR TITLE
[monorepo] fix: set the discord web hook url

### DIFF
--- a/core/Jenkinsfile
+++ b/core/Jenkinsfile
@@ -7,5 +7,6 @@ defaultCiPipeline {
 	packageId = 'nem-core'
 
 	codeCoverageTool = 'jacoco'
-}
 
+	discordWebHookUrlId = 'CLIENT_DISCORD_WEB_HOOK_URL_ID'
+}

--- a/core/Jenkinsfile
+++ b/core/Jenkinsfile
@@ -8,5 +8,5 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'jacoco'
 
-	discordWebHookUrlId = 'CLIENT_DISCORD_WEB_HOOK_URL_ID'
+	discordWebHookUrlId = 'SDK_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/deploy/Jenkinsfile
+++ b/deploy/Jenkinsfile
@@ -7,5 +7,6 @@ defaultCiPipeline {
 	packageId = 'nem-deploy'
 
 	codeCoverageTool = 'jacoco'
-}
 
+	discordWebHookUrlId = 'CLIENT_DISCORD_WEB_HOOK_URL_ID'
+}

--- a/nis/Jenkinsfile
+++ b/nis/Jenkinsfile
@@ -11,4 +11,6 @@ defaultCiPipeline {
 	packageId = 'nem-nis'
 
 	codeCoverageTool = 'jacoco'
+
+	discordWebHookUrlId = 'CLIENT_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/peer/Jenkinsfile
+++ b/peer/Jenkinsfile
@@ -7,5 +7,6 @@ defaultCiPipeline {
 	packageId = 'nem-peer'
 
 	codeCoverageTool = 'jacoco'
-}
 
+	discordWebHookUrlId = 'CLIENT_DISCORD_WEB_HOOK_URL_ID'
+}


### PR DESCRIPTION
problem: all build status messages go to one discord channel
solution: set the discord webhook ID to send the build status