### PR TITLE
[nis] fix: getAccountOwnedMosaics failed on expired mosaics

### DIFF
--- a/nis/src/main/java/org/nem/nis/service/MosaicInfoFactory.java
+++ b/nis/src/main/java/org/nem/nis/service/MosaicInfoFactory.java
@@ -72,6 +72,7 @@ public class MosaicInfoFactory {
 		return Stream.concat(Stream.of(nemXemBalance), accountState.getAccountInfo().getMosaicIds().stream()
 				.filter(mosaicId -> null != this.namespaceCache.get(mosaicId.getNamespaceId()))
 				.map(mosaicId -> this.namespaceCache.get(mosaicId.getNamespaceId()).getMosaics().get(mosaicId))
+				.filter(Objects::nonNull)
 				.map(entry -> new Mosaic(entry.getMosaicDefinition().getId(), entry.getBalances().getBalance(accountState.getAddress()))))
 				.collect(Collectors.toList());
 	}

--- a/nis/src/test/java/org/nem/nis/service/MosaicInfoFactoryTest.java
+++ b/nis/src/test/java/org/nem/nis/service/MosaicInfoFactoryTest.java
@@ -56,10 +56,14 @@ public class MosaicInfoFactoryTest {
 		public TestContext() {
 			final NamespaceId namespaceId1 = new NamespaceId("foo");
 			final NamespaceId namespaceId2 = new NamespaceId("baz");
+			final NamespaceId namespaceIdNoMosaicId = new NamespaceId("nomosaic");
 			final MosaicId mosaicId1 = new MosaicId(namespaceId1, "bar");
 			final MosaicId mosaicId2 = new MosaicId(namespaceId2, "qux");
+			final MosaicId mosaicIdNotInNamespace = new MosaicId(namespaceIdNoMosaicId, "crash");
+
 			this.accountState.getAccountInfo().addMosaicId(mosaicId1);
 			this.accountState.getAccountInfo().addMosaicId(mosaicId2);
+			this.accountState.getAccountInfo().addMosaicId(mosaicIdNotInNamespace);
 			Mockito.when(this.accountStateCache.findStateByAddress(this.address)).thenReturn(this.accountState);
 
 			final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
@@ -71,6 +75,12 @@ public class MosaicInfoFactoryTest {
 			final NamespaceEntry namespaceEntry = new NamespaceEntry(namespace, mosaics);
 			Mockito.when(this.namespaceCache.get(namespaceId1)).thenReturn(namespaceEntry);
 			Mockito.when(this.namespaceCache.get(namespaceId2)).thenReturn(null);
+
+			// Add regression crash for when namespace is valid but mosaic entry is not present
+			final Namespace namespaceNoMosaicIdEntry = new Namespace(namespaceId1, Utils.generateRandomAccount(), BlockHeight.ONE);
+			final Mosaics mosaicsEmpty = new Mosaics(namespaceNoMosaicIdEntry.getId(), forkConfiguration.getMosaicRedefinitionForkHeight());
+			final NamespaceEntry namespaceEntryNoMosaic = new NamespaceEntry(namespaceNoMosaicIdEntry, mosaicsEmpty);
+			Mockito.when(this.namespaceCache.get(namespaceIdNoMosaicId)).thenReturn(namespaceEntryNoMosaic);
 		}
 	}
 }


### PR DESCRIPTION
problem: Mosaic which has expired causes the lookup of the mosaicId in the namespace to be null.
         This causes a NullPointerException when trying to get the Mosaic definition.
solution: Filter all Mosiacs entries which failed to resolve from the namespace.