### PR TITLE
[gocrypto]: create go package containing custom ed25519 implementation

### DIFF
--- a/gocrypto/ed25519.go
+++ b/gocrypto/ed25519.go
@@ -1,0 +1,243 @@
+package ed25519
+
+import (
+	"bytes"
+	"crypto"
+	cryptorand "crypto/rand"
+	"crypto/subtle"
+	"hash"
+	"io"
+	"strconv"
+	"filippo.io/edwards25519"
+)
+
+// region constants
+
+const (
+	// PublicKeySize is the size, in bytes, of public keys as used in this package.
+	PublicKeySize = 32
+	// PrivateKeySize is the size, in bytes, of private keys as used in this package.
+	PrivateKeySize = 64
+	// SignatureSize is the size, in bytes, of signatures generated and verified by this package.
+	SignatureSize = 64
+	// SeedSize is the size, in bytes, of private key seeds. These are the private key representations used by RFC 8032.
+	SeedSize = 32
+)
+
+// endregion
+
+// region PublicKey / PrivateKey
+
+// PublicKey is the type of Ed25519 public keys.
+type PublicKey []byte
+
+// Any methods implemented on PublicKey might need to also be implemented on
+// PrivateKey, as the latter embeds the former and will expose its methods.
+
+// Equal reports whether pub and x have the same value.
+func (pub PublicKey) Equal(x crypto.PublicKey) bool {
+	xx, ok := x.(PublicKey)
+	if !ok {
+		return false
+	}
+	return subtle.ConstantTimeCompare(pub, xx) == 1
+}
+
+// PrivateKey is the type of Ed25519 private keys. It implements [crypto.Signer].
+type PrivateKey []byte
+
+// Seed returns the private key seed corresponding to priv. It is provided for
+// interoperability with RFC 8032. RFC 8032's private keys correspond to seeds
+// in this package.
+func (priv PrivateKey) Seed() []byte {
+	return bytes.Clone(priv[:SeedSize])
+}
+
+// Public returns the [PublicKey] corresponding to priv.
+func (priv PrivateKey) Public() crypto.PublicKey {
+	publicKey := make([]byte, PublicKeySize)
+	copy(publicKey, priv[32:])
+	return PublicKey(publicKey)
+}
+
+// Equal reports whether priv and x have the same value.
+func (priv PrivateKey) Equal(x crypto.PrivateKey) bool {
+	xx, ok := x.(PrivateKey)
+	if !ok {
+		return false
+	}
+	return subtle.ConstantTimeCompare(priv, xx) == 1
+}
+
+// endregion
+
+// region GenerateKey / NewKeyFromSeed
+
+// GenerateKey generates a public/private key pair using entropy from rand.
+// If rand is nil, [crypto/rand.Reader] will be used.
+//
+// The output of this function is deterministic, and equivalent to reading
+// [SeedSize] bytes from rand, and passing them to [NewKeyFromSeed].
+//
+// A custom hash function can be supplied in order to allow support of
+// non-standard Ed25519 signature systems.
+func GenerateKey(rand io.Reader, hasher hash.Hash) (PublicKey, PrivateKey, error) {
+	if rand == nil {
+		rand = cryptorand.Reader
+	}
+
+	seed := make([]byte, SeedSize)
+	if _, err := io.ReadFull(rand, seed); err != nil {
+		return nil, nil, err
+	}
+
+	privateKey := NewKeyFromSeed(seed, hasher)
+	publicKey := make([]byte, PublicKeySize)
+	copy(publicKey, privateKey[32:])
+
+	return publicKey, privateKey, nil
+}
+
+// NewKeyFromSeed calculates a private key from a seed. It will panic if
+// len(seed) is not [SeedSize]. This function is provided for interoperability
+// with RFC 8032. RFC 8032's private keys correspond to seeds in this
+// package.
+//
+// A custom hash function can be supplied in order to allow support of
+// non-standard Ed25519 signature systems.
+func NewKeyFromSeed(seed []byte, hasher hash.Hash) PrivateKey {
+	// Outline the function body so that the returned key can be stack-allocated.
+	privateKey := make([]byte, PrivateKeySize)
+
+	if l := len(seed); l != SeedSize {
+		panic("ed25519: bad seed length: " + strconv.Itoa(l))
+	}
+
+	hasher.Reset()
+	hasher.Write(seed)
+	h := make([]byte, 0, hasher.Size())
+	h = hasher.Sum(h)
+
+	s, err := edwards25519.NewScalar().SetBytesWithClamping(h[:32])
+	if err != nil {
+		panic("ed25519: internal error: setting scalar failed")
+	}
+	A := (&edwards25519.Point{}).ScalarBaseMult(s)
+
+	publicKey := A.Bytes()
+
+	copy(privateKey, seed)
+	copy(privateKey[32:], publicKey)
+
+	return privateKey
+}
+
+// endregion
+
+// region Sign
+
+// Sign signs the message with privateKey and returns a signature. It will
+// panic if len(privateKey) is not [PrivateKeySize].
+//
+// A custom hash function can be supplied in order to allow support of
+// non-standard Ed25519 signature systems.
+func Sign(privateKey PrivateKey, message []byte, hasher hash.Hash) []byte {
+	// Outline the function body so that the returned signature can be stack-allocated.
+	signature := make([]byte, SignatureSize)
+
+	if l := len(privateKey); l != PrivateKeySize {
+		panic("ed25519: bad private key length: " + strconv.Itoa(l))
+	}
+	seed, publicKey := privateKey[:SeedSize], privateKey[SeedSize:]
+
+	hasher.Reset()
+	hasher.Write(seed)
+	h := make([]byte, 0, hasher.Size())
+	h = hasher.Sum(h)
+
+	s, err := edwards25519.NewScalar().SetBytesWithClamping(h[:32])
+	if err != nil {
+		panic("ed25519: internal error: setting scalar failed")
+	}
+	prefix := h[32:]
+
+	hasher.Reset()
+	hasher.Write(prefix)
+	hasher.Write(message)
+	messageDigest := make([]byte, 0, hasher.Size())
+	messageDigest = hasher.Sum(messageDigest)
+	r, err := edwards25519.NewScalar().SetUniformBytes(messageDigest)
+	if err != nil {
+		panic("ed25519: internal error: setting scalar failed")
+	}
+
+	R := (&edwards25519.Point{}).ScalarBaseMult(r)
+
+	hasher.Reset()
+	hasher.Write(R.Bytes())
+	hasher.Write(publicKey)
+	hasher.Write(message)
+	hramDigest := make([]byte, 0, hasher.Size())
+	hramDigest = hasher.Sum(hramDigest)
+	k, err := edwards25519.NewScalar().SetUniformBytes(hramDigest)
+	if err != nil {
+		panic("ed25519: internal error: setting scalar failed")
+	}
+
+	S := edwards25519.NewScalar().MultiplyAdd(k, s, r)
+
+	copy(signature[:32], R.Bytes())
+	copy(signature[32:], S.Bytes())
+	return signature
+}
+
+// endregion
+
+// region Verify
+
+// Verify reports whether sig is a valid signature of message by publicKey. It
+// will panic if len(publicKey) is not [PublicKeySize].
+//
+// The inputs are not considered confidential, and may leak through timing side
+// channels, or if an attacker has control of part of the inputs.
+//
+// A custom hash function can be supplied in order to allow support of
+// non-standard Ed25519 signature systems.
+func Verify(publicKey PublicKey, message, sig []byte, hasher hash.Hash) bool {
+	if l := len(publicKey); l != PublicKeySize {
+		panic("ed25519: bad public key length: " + strconv.Itoa(l))
+	}
+
+	if len(sig) != SignatureSize || sig[63]&224 != 0 {
+		return false
+	}
+
+	A, err := (&edwards25519.Point{}).SetBytes(publicKey)
+	if err != nil {
+		return false
+	}
+
+	hasher.Reset()
+	hasher.Write(sig[:32])
+	hasher.Write(publicKey)
+	hasher.Write(message)
+	hramDigest := make([]byte, 0, hasher.Size())
+	hramDigest = hasher.Sum(hramDigest)
+	k, err := edwards25519.NewScalar().SetUniformBytes(hramDigest)
+	if err != nil {
+		panic("ed25519: internal error: setting scalar failed")
+	}
+
+	S, err := edwards25519.NewScalar().SetCanonicalBytes(sig[32:])
+	if err != nil {
+		return false
+	}
+
+	// [S]B = R + [k]A --> [k](-A) + [S]B = R
+	minusA := (&edwards25519.Point{}).Negate(A)
+	R := (&edwards25519.Point{}).VarTimeDoubleScalarBaseMult(k, minusA, S)
+
+	return bytes.Equal(sig[:32], R.Bytes())
+}
+
+// endregion

--- a/gocrypto/ed25519_test.go
+++ b/gocrypto/ed25519_test.go
@@ -1,0 +1,406 @@
+package ed25519
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/hex"
+	"testing"
+
+	"golang.org/x/crypto/sha3"
+)
+
+// region constants / utils
+
+var ZERO_PRIVATE_KEY = "0000000000000000000000000000000000000000000000000000000000000000"
+var ZERO_PUBLIC_KEY = "3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29"
+
+var DETERMINISTIC_PRIVATE_KEY = "575DBB3062267EFF57C970A336EBBC8FBCFE12C5BD3ED7BC11EB0481D7704CED"
+var DETERMINISTIC_PUBLIC_KEY = "D6C3845431236C5A5A907A9E45BD60DA0E12EFD350B970E7F58E3499E2E7A2F0"
+
+func ReverseInPlace(buf []byte) {
+	for i, j := 0, len(buf) - 1; i < j; i, j = i + 1, j - 1 {
+		buf[i], buf[j] = buf[j], buf[i]
+	}
+}
+
+// endregion
+
+// region PublicKey / PrivateKey
+
+func TestPublicKey_Equality(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	public1, _, _ := GenerateKey(rand.Reader, hasher)
+	public2, _, _ := GenerateKey(rand.Reader, hasher)
+
+	// Act + Assert:
+	if !public1.Equal(public1) || !public2.Equal(public2) {
+		t.Errorf("public key is not equal to itself")
+	}
+
+	if public1.Equal(public2) || public2.Equal(public1) {
+		t.Errorf("different public keys are equal")
+	}
+
+	public1Copy := make([]byte, len(public1))
+	copy(public1Copy, public1)
+	if public1.Equal(crypto.PublicKey(public1Copy)) {
+		t.Errorf("different public key types are equal")
+	}
+}
+
+func TestPrivateKey_Equality(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	_, private1, _ := GenerateKey(rand.Reader, hasher)
+	_, private2, _ := GenerateKey(rand.Reader, hasher)
+
+	// Act + Assert:
+	if !private1.Equal(private1) || !private2.Equal(private2) {
+		t.Errorf("private key is not equal to itself")
+	}
+
+	if private1.Equal(private2) || private2.Equal(private1) {
+		t.Errorf("different private keys are equal")
+	}
+
+	private1Copy := make([]byte, len(private1))
+	copy(private1Copy, private1)
+	if private1.Equal(crypto.PrivateKey(private1Copy)) {
+		t.Errorf("different private key types are equal")
+	}
+}
+
+// region GenerateKey / NewKeyFromSeed
+
+func AssertZeroPrivateKey(t *testing.T, private PrivateKey) {
+	expectedPrivate, _ := hex.DecodeString(ZERO_PRIVATE_KEY)
+	if !bytes.Equal(expectedPrivate, private[:32]) {
+		t.Errorf("private key [private] was not derived correctly")
+	}
+
+	expectedPublic, _ := hex.DecodeString(ZERO_PUBLIC_KEY)
+	if !bytes.Equal(expectedPublic, private[32:]) {
+		t.Errorf("private key [public] was not derived correctly")
+	}
+
+	if !bytes.Equal(expectedPrivate, private.Seed()) {
+		t.Errorf("private key [Seed()] was not derived correctly")
+	}
+
+	if !bytes.Equal(expectedPublic, private.Public().(PublicKey)) {
+		t.Errorf("private key [Public()] was not derived correctly")
+	}
+}
+
+func AssertDeterministicPrivateKey(t *testing.T, private PrivateKey) {
+	expectedPrivate, _ := hex.DecodeString(DETERMINISTIC_PRIVATE_KEY)
+	if !bytes.Equal(expectedPrivate, private[:32]) {
+		t.Errorf("private key [private] was not derived correctly")
+	}
+
+	expectedPublic, _ := hex.DecodeString(DETERMINISTIC_PUBLIC_KEY)
+	if !bytes.Equal(expectedPublic, private[32:]) {
+		t.Errorf("private key [public] was not derived correctly")
+	}
+
+	if !bytes.Equal(expectedPrivate, private.Seed()) {
+		t.Errorf("private key [Seed()] was not derived correctly")
+	}
+
+	if !bytes.Equal(expectedPublic, private.Public().(PublicKey)) {
+		t.Errorf("private key [Public()] was not derived correctly")
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(buf []byte) (int, error) {
+	clear(buf)
+	return len(buf), nil
+}
+
+type deterministicReader struct{}
+
+func (deterministicReader) Read(buf []byte) (int, error) {
+	seed, _ := hex.DecodeString(DETERMINISTIC_PRIVATE_KEY)
+
+	copy(buf, seed)
+	return len(buf), nil
+}
+
+func TestGenerateKey_Zero(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	var reader zeroReader
+
+	// Act:
+	public, private, _ := GenerateKey(reader, hasher)
+
+	// Assert:
+	AssertZeroPrivateKey(t, private)
+
+	if !PublicKey(public).Equal(private.Public())  {
+		t.Errorf("public key returned does not match public key derived from private key")
+	}
+}
+
+func TestGenerateKey_Deterministic(t *testing.T) {
+	// Arrange:
+	hasher := sha3.NewLegacyKeccak512()
+	var reader deterministicReader
+
+	// Act:
+	public, private, _ := GenerateKey(reader, hasher)
+
+	// Assert:
+	AssertDeterministicPrivateKey(t, private)
+
+	if !PublicKey(public).Equal(private.Public())  {
+		t.Errorf("public key returned does not match public key derived from private key")
+	}
+}
+
+func TestNewKeyFromSeed_Zero(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	seed, _ := hex.DecodeString(ZERO_PRIVATE_KEY)
+
+	// Act:
+	private := NewKeyFromSeed(seed, hasher)
+
+	// Assert:
+	AssertZeroPrivateKey(t, private)
+}
+
+func TestNewKeyFromSeed_Deterministic(t *testing.T) {
+	// Arrange:
+	hasher := sha3.NewLegacyKeccak512()
+	seed, _ := hex.DecodeString(DETERMINISTIC_PRIVATE_KEY)
+
+	// Act:
+	private := NewKeyFromSeed(seed, hasher)
+
+	// Assert:
+	AssertDeterministicPrivateKey(t, private)
+}
+
+// endregion
+
+// region Sign
+
+func TestSign_FillsSignature(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	seed, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	private := NewKeyFromSeed(seed, hasher)
+
+	message, _ := hex.DecodeString("1234567890")
+
+	// Act:
+	signature := Sign(private, message, hasher)
+
+	// Assert:
+	zeroSignature := [64]byte {}
+	if bytes.Equal(zeroSignature[:], signature) {
+		t.Errorf("signature is zero")
+	}
+}
+
+func TestSign_SameSignaturesForSameKeyPairs(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	seed1, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	private1 := NewKeyFromSeed(seed1, hasher)
+
+	seed2, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	private2 := NewKeyFromSeed(seed2, hasher)
+
+	message, _ := hex.DecodeString("1234567890")
+
+	// Act:
+	signature1 := Sign(private1, message, hasher)
+	signature2 := Sign(private2, message, hasher)
+
+	// Assert:
+	if !bytes.Equal(signature1, signature2) {
+		t.Errorf("signatures should be equal")
+	}
+}
+
+func TestSign_DifferentSignaturesForDifferentKeyPairs(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	seed1, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	private1 := NewKeyFromSeed(seed1, hasher)
+
+	seed2, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000001")
+	private2 := NewKeyFromSeed(seed2, hasher)
+
+	message, _ := hex.DecodeString("1234567890")
+
+	// Act:
+	signature1 := Sign(private1, message, hasher)
+	signature2 := Sign(private2, message, hasher)
+
+	// Assert:
+	if bytes.Equal(signature1, signature2) {
+		t.Errorf("signatures should be different")
+	}
+}
+
+// endregion
+
+// region Verify
+
+func TestVerify_CanVerify(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	seed, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	private := NewKeyFromSeed(seed, hasher)
+
+	message, _ := hex.DecodeString("1234567890")
+
+	signature := Sign(private, message, hasher)
+
+	// Act:
+	isVerified := Verify(private.Public().(PublicKey), message, signature, hasher)
+
+	// Assert:
+	if !isVerified {
+		t.Errorf("signature cannot be verified")
+	}
+}
+
+func TestVerify_CannotVerifyWithDifferentKeyPair(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	seed1, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	private1 := NewKeyFromSeed(seed1, hasher)
+
+	seed2, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000001")
+	private2 := NewKeyFromSeed(seed2, hasher)
+
+	message, _ := hex.DecodeString("1234567890")
+
+	signature := Sign(private1, message, hasher)
+
+	// Act:
+	isVerified := Verify(private2.Public().(PublicKey), message, signature, hasher)
+
+	// Assert:
+	if isVerified {
+		t.Errorf("signature should not be verified")
+	}
+}
+
+func TestVerify_CannotVerifyWithDifferentMessage(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	seed, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	private := NewKeyFromSeed(seed, hasher)
+
+	message1, _ := hex.DecodeString("1234567890")
+	message2, _ := hex.DecodeString("1234567890ABCDEF")
+
+	signature := Sign(private, message1, hasher)
+
+	// Act:
+	isVerified := Verify(private.Public().(PublicKey), message2, signature, hasher)
+
+	// Assert:
+	if isVerified {
+		t.Errorf("signature should not be verified")
+	}
+}
+
+func TestVerify_CannotVerifyWithDifferentSignature(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	seed, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	private := NewKeyFromSeed(seed, hasher)
+
+	message, _ := hex.DecodeString("1234567890")
+
+	signature := Sign(private, message, hasher)
+	signature[0] ^= 0xFF
+
+	// Act:
+	isVerified := Verify(private.Public().(PublicKey), message, signature, hasher)
+
+	// Assert:
+	if isVerified {
+		t.Errorf("signature should not be verified")
+	}
+}
+
+func TestVerify_CannotVerifyWithZeroS(t *testing.T) {
+	// Arrange:
+	hasher := sha512.New()
+	seed, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	private := NewKeyFromSeed(seed, hasher)
+
+	message, _ := hex.DecodeString("1234567890")
+
+	signature := Sign(private, message, hasher)
+	signatureZeroS := make([]byte, len(signature))
+	copy(signatureZeroS, signature[:32])
+
+	// Act:
+	isVerified := Verify(private.Public().(PublicKey), message, signature, hasher)
+	isVerifiedZeroS := Verify(private.Public().(PublicKey), message, signatureZeroS, hasher)
+
+	// Assert:
+	if !isVerified {
+		t.Errorf("signature cannot be verified")
+	}
+
+	if isVerifiedZeroS {
+		t.Errorf("zero S signature should not be verified")
+	}
+}
+
+func ScalarAddGroupOrder(scalar []byte) []byte {
+	// 2^252 + 27742317777372353535851937790883648493, little endian
+	groupOrder, _ := hex.DecodeString("EDD3F55C1A631258D69CF7A2DEF9DE1400000000000000000000000000000010")
+	remainder := 0
+
+	for i, groupOrderByte := range groupOrder {
+		byteSum := int(scalar[i]) + int(groupOrderByte);
+		scalar[i] = byte((byteSum + remainder) & 0xFF);
+		remainder = (byteSum >> 8) & 0xFF;
+	}
+
+	return scalar
+}
+
+func TestVerify_CannotVerifyNonCanonicalSignature(t *testing.T) {
+	// Arrange: the value 30 in the payload ensures that the encodedS part of the signature is < 2 ^ 253 after adding the group order
+	hasher := sha512.New()
+	seed, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	private := NewKeyFromSeed(seed, hasher)
+
+	message, _ := hex.DecodeString("0102030405060708091D")
+
+	canonicalSignature := Sign(private, message, hasher)
+	nonCanonicalSignature := make([]byte, len(canonicalSignature))
+	copy(nonCanonicalSignature, canonicalSignature)
+	ScalarAddGroupOrder(nonCanonicalSignature[32:])
+
+	// Act:
+	isVerifiedCanonical := Verify(private.Public().(PublicKey), message, canonicalSignature, hasher)
+	isVerifiedNonCanonical := Verify(private.Public().(PublicKey), message, nonCanonicalSignature, hasher)
+
+	// Assert:
+	if !isVerifiedCanonical {
+		t.Errorf("canonical signature cannot be verified")
+	}
+
+	if isVerifiedNonCanonical {
+		t.Errorf("non-canonical signature should not be verified")
+	}
+}
+
+// endregion

--- a/gocrypto/ed25519_vectors_test.go
+++ b/gocrypto/ed25519_vectors_test.go
@@ -1,0 +1,135 @@
+package ed25519
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"golang.org/x/crypto/sha3"
+)
+
+// region utils
+
+var EXPECTED_TEST_CASES_COUNT = 10000
+
+type runTestCase[TTestCase any] func(TTestCase) bool
+
+func RunTestVectors[TTestCase any](t *testing.T, filename string, runTestCase runTestCase[TTestCase]) {
+	content, err := ioutil.ReadFile(fmt.Sprintf("../tests/vectors/nem/crypto/%s", filename))
+	if nil != err {
+		t.Fatal("error when opening file: ", err)
+	}
+
+	var testCases []TTestCase
+	err = json.Unmarshal(content, &testCases)
+	if nil != err {
+		t.Fatal("error during Unmarshal(): ", err)
+	}
+
+	testsCount := 0
+	failedTestsCount := 0
+	for _, testCase := range testCases {
+		if !runTestCase(testCase) {
+			failedTestsCount += 1
+		}
+
+		testsCount += 1
+	}
+
+	if EXPECTED_TEST_CASES_COUNT != testsCount {
+		t.Errorf("unexpected number of tests run (%d)", testsCount)
+	}
+
+	if 0 != failedTestsCount {
+		t.Errorf("%d test(s) failed ", failedTestsCount)
+	}
+}
+
+// endregion
+
+// region KeyConversion
+
+type KeyConversionTestCase struct {
+	PrivateKey string
+	PublicKey string
+}
+
+func TestVectors_KeyConversion(t *testing.T) {
+	hasher := sha3.NewLegacyKeccak512()
+	RunTestVectors(t, "1.test-keys.json", func(testCase KeyConversionTestCase) bool {
+		// Arrange:
+		privateKey, _ := hex.DecodeString(testCase.PrivateKey);
+		expectedPublicKey, _ := hex.DecodeString(testCase.PublicKey);
+
+		seed := make([]byte, len(privateKey))
+		copy(seed, privateKey)
+		ReverseInPlace(seed)
+
+		// Act:
+		actualPrivateKey := NewKeyFromSeed(seed, hasher)
+		actualPublicKey := actualPrivateKey.Public()
+
+		// Assert:
+		return PublicKey(expectedPublicKey).Equal(actualPublicKey)
+	})
+}
+
+// endregion
+
+// region Sign
+
+type SignTestCase struct {
+	PrivateKey string
+	Data string
+	Signature string
+}
+
+func TestVectors_Sign(t *testing.T) {
+	hasher := sha3.NewLegacyKeccak512()
+	RunTestVectors(t, "2.test-sign.json", func(testCase SignTestCase) bool {
+		// Arrange:
+		privateKeySeed, _ := hex.DecodeString(testCase.PrivateKey)
+		message, _ := hex.DecodeString(testCase.Data)
+		expectedSignature, _ := hex.DecodeString(testCase.Signature)
+
+		ReverseInPlace(privateKeySeed)
+		privateKey := NewKeyFromSeed(privateKeySeed, hasher)
+
+		// Act:
+		actualSignature := Sign(privateKey, message, hasher)
+
+		// Assert:
+		return bytes.Equal(expectedSignature, actualSignature)
+	})
+}
+
+// endregion
+
+// region Verify
+
+type VerifyTestCase struct {
+	PublicKey string
+	Data string
+	Signature string
+}
+
+func TestVectors_Verify(t *testing.T) {
+	hasher := sha3.NewLegacyKeccak512()
+	RunTestVectors(t, "2.test-sign.json", func(testCase VerifyTestCase) bool {
+		// Arrange:
+		publicKey, _ := hex.DecodeString(testCase.PublicKey)
+		message, _ := hex.DecodeString(testCase.Data)
+		signature, _ := hex.DecodeString(testCase.Signature)
+
+		// Act:
+		isVerified := Verify(publicKey, message, signature, hasher)
+
+		// Assert:
+		return isVerified
+	})
+}
+
+// endregion

--- a/gocrypto/go.mod
+++ b/gocrypto/go.mod
@@ -1,0 +1,9 @@
+module NemProject/gocrypto
+
+go 1.22.5
+
+require (
+	filippo.io/edwards25519 v1.1.0 // indirect
+	golang.org/x/crypto v0.25.0 // indirect
+	golang.org/x/sys v0.22.0 // indirect
+)

--- a/gocrypto/go.sum
+++ b/gocrypto/go.sum
@@ -1,0 +1,6 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+golang.org/x/crypto v0.25.0 h1:ypSNr+bnYL2YhwoMt2zPxHFmbAN1KZs/njMG3hxUp30=
+golang.org/x/crypto v0.25.0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/init.sh
+++ b/init.sh
@@ -1,11 +1,10 @@
-
 #!/bin/bash
 
 set -ex
 
 git submodule update --init
 git -C _symbol config core.sparseCheckout true
-echo 'jenkins/*' >>.git/modules/_symbol/info/sparse-checkout
-echo 'linters/*' >>.git/modules/_symbol/info/sparse-checkout
+echo 'jenkins/*' >> .git/modules/_symbol/info/sparse-checkout
+echo 'linters/*' >> .git/modules/_symbol/info/sparse-checkout
+echo 'tests/*' >> .git/modules/_symbol/info/sparse-checkout
 git submodule update --force --checkout _symbol
-

--- a/tests
+++ b/tests
@@ -1,0 +1,1 @@
+_symbol/tests


### PR DESCRIPTION
 problem: NEM uses a non-standard ed25519 signature scheme
          it uses Keccak512 as hash function instead of standard SHA512
solution:
         * create a copy of ed25519.go from golang/go
         * modify it to allow specification of hash function
         * port unit tests and test vectors from symbol/symbol SDKs