### PR TITLE
[nis]: block lessor is not set correctly in database in all cases

### DIFF
--- a/nis/src/main/java/org/nem/nis/cache/DefaultAccountStateCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/DefaultAccountStateCache.java
@@ -153,11 +153,11 @@ public class DefaultAccountStateCache implements ExtendedAccountStateCache<Defau
 		public AccountState findForwardedStateByAddress(final Address address, final BlockHeight height) {
 			final AccountState state = this.findStateByAddress(address);
 			final ReadOnlyRemoteLinks remoteLinks = state.getRemoteLinks();
-			if (!remoteLinks.isRemoteHarvester()) {
+			if (!remoteLinks.isRemoteHarvesterAt(height)) {
 				return state;
 			}
 
-			final RemoteLink remoteLink = remoteLinks.getCurrent();
+			final RemoteLink remoteLink = remoteLinks.getActive(height);
 			final long settingHeight = height.subtract(remoteLink.getEffectiveHeight());
 			final int remoteHarvestingDelay = NemGlobals.getBlockChainConfiguration().getBlockChainRewriteLimit();
 			boolean shouldUseRemote = false;

--- a/nis/src/main/java/org/nem/nis/state/ReadOnlyRemoteLinks.java
+++ b/nis/src/main/java/org/nem/nis/state/ReadOnlyRemoteLinks.java
@@ -12,12 +12,21 @@ public interface ReadOnlyRemoteLinks {
 	boolean isEmpty();
 
 	/**
-	 * Gets a value indicating whether or the owning account has enabled remote harvesting and is forwarding its harvesting power to a
+	 * Gets a value indicating whether or not the owning account has enabled remote harvesting and is forwarding its harvesting power to a
 	 * remote account.
 	 *
 	 * @return true if the owning account has enabled remote harvesting.
 	 */
 	boolean isHarvestingRemotely();
+
+	/**
+	 * Gets a value indicating whether or not the owning account has enabled remote harvesting and is forwarding its harvesting power to a
+	 * remote account at the specified block height.
+	 *
+	 * @param height The block height.
+	 * @return true if the owning account has enabled remote harvesting at the specified block height.
+	 */
+	boolean isHarvestingRemotelyAt(final BlockHeight height);
 
 	/**
 	 * Gets a value indicating whether or not the owning account is a remote harvester account.
@@ -27,11 +36,27 @@ public interface ReadOnlyRemoteLinks {
 	boolean isRemoteHarvester();
 
 	/**
+	 * Gets a value indicating whether or not the owning account is a remote harvester account at the specified block height.
+	 *
+	 * @param height The block height.
+	 * @return true if the owning account is a remote harvester at the specified block heighte.
+	 */
+	boolean isRemoteHarvesterAt(final BlockHeight height);
+
+	/**
 	 * Gets the current remote link.
 	 *
 	 * @return The current remote link.
 	 */
 	RemoteLink getCurrent();
+
+	/**
+	 * Gets the remote link active at the specified block height.
+	 *
+	 * @param height The block height.
+	 * @return The active remote link at the specified block height.
+	 */
+	RemoteLink getActive(final BlockHeight height);
 
 	/**
 	 * Gets the remote status at the specified block height.

--- a/nis/src/test/java/org/nem/nis/cache/AccountStateCacheTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/AccountStateCacheTest.java
@@ -372,6 +372,25 @@ public abstract class AccountStateCacheTest<T extends ExtendedAccountStateCache<
 		return forwardedState.equals(state);
 	}
 
+	@Test
+	public void findForwardedStateByAddressIsHeightAware() {
+		// Arrange:
+		final Address address = Utils.generateRandomAddress();
+		final T cache = this.createCacheWithoutAutoCache();
+		final AccountState state = this.addToCache(cache.copy(), address);
+
+		final RemoteLink link1 = new RemoteLink(Utils.generateRandomAddress(), new BlockHeight(1000), ACTIVATE, RemoteLink.Owner.RemoteHarvester);
+		final RemoteLink link2 = new RemoteLink(Utils.generateRandomAddress(), new BlockHeight(2000), ACTIVATE, RemoteLink.Owner.HarvestingRemotely);
+		state.getRemoteLinks().addLink(link1);
+		state.getRemoteLinks().addLink(link2);
+
+		// Act:
+		final AccountState forwardedState = cache.findForwardedStateByAddress(address, new BlockHeight(1500));
+
+		// Assert: second link is ignored because 2000 > 1500
+		MatcherAssert.assertThat(forwardedState.getAddress(), IsEqual.equalTo(link1.getLinkedAddress()));
+	}
+
 	// endregion
 
 	// region removeFromCache

--- a/nis/src/test/java/org/nem/nis/chain/integration/RealBlockChainTestContext.java
+++ b/nis/src/test/java/org/nem/nis/chain/integration/RealBlockChainTestContext.java
@@ -97,6 +97,10 @@ public class RealBlockChainTestContext {
 		this.blockChainLastBlockLayer.analyzeLastBlock(dbBlock);
 	}
 
+	public BlockHeight getInitialBlockHeight() {
+		return this.initialBlockHeight;
+	}
+
 	// region mapping helpers
 
 	/**

--- a/nis/src/test/java/org/nem/nis/state/RemoteLinksTest.java
+++ b/nis/src/test/java/org/nem/nis/state/RemoteLinksTest.java
@@ -225,6 +225,65 @@ public class RemoteLinksTest {
 
 	// endregion
 
+	// region height dependent accessors
+
+	@Test
+	public void canAccessRemoteLinkAtHeight() {
+		// Arrange:
+		final RemoteLinks links = new RemoteLinks();
+
+		// Act:
+		final RemoteLink link1 = RemoteLinkFactory.activateRemoteHarvester(Utils.generateRandomAddress(), new BlockHeight(7));
+		final RemoteLink link2 = RemoteLinkFactory.activateHarvestingRemotely(Utils.generateRandomAddress(), new BlockHeight(9));
+		links.addLink(link1);
+		links.addLink(link2);
+
+		// Assert:
+		MatcherAssert.assertThat(links.isEmpty(), IsEqual.equalTo(false));
+
+		// - isHarvestingRemotelyAt is height dependent
+		MatcherAssert.assertThat(links.isHarvestingRemotelyAt(new BlockHeight(6)), IsEqual.equalTo(false));
+		MatcherAssert.assertThat(links.isHarvestingRemotelyAt(new BlockHeight(7)), IsEqual.equalTo(false));
+		MatcherAssert.assertThat(links.isHarvestingRemotelyAt(new BlockHeight(8)), IsEqual.equalTo(false));
+		MatcherAssert.assertThat(links.isHarvestingRemotelyAt(new BlockHeight(9)), IsEqual.equalTo(true));
+		MatcherAssert.assertThat(links.isHarvestingRemotelyAt(new BlockHeight(10)), IsEqual.equalTo(true));
+
+		// - isRemoteHarvesterAt is height dependent
+		MatcherAssert.assertThat(links.isRemoteHarvesterAt(new BlockHeight(6)), IsEqual.equalTo(false));
+		MatcherAssert.assertThat(links.isRemoteHarvesterAt(new BlockHeight(7)), IsEqual.equalTo(true));
+		MatcherAssert.assertThat(links.isRemoteHarvesterAt(new BlockHeight(8)), IsEqual.equalTo(true));
+		MatcherAssert.assertThat(links.isRemoteHarvesterAt(new BlockHeight(9)), IsEqual.equalTo(false));
+		MatcherAssert.assertThat(links.isRemoteHarvesterAt(new BlockHeight(10)), IsEqual.equalTo(false));
+
+		// - getActive is height dependent
+		MatcherAssert.assertThat(links.getActive(new BlockHeight(6)), IsEqual.equalTo(null));
+		MatcherAssert.assertThat(links.getActive(new BlockHeight(7)), IsEqual.equalTo(link1));
+		MatcherAssert.assertThat(links.getActive(new BlockHeight(8)), IsEqual.equalTo(link1));
+		MatcherAssert.assertThat(links.getActive(new BlockHeight(9)), IsEqual.equalTo(link2));
+		MatcherAssert.assertThat(links.getActive(new BlockHeight(10)), IsEqual.equalTo(link2));
+	}
+
+	@Test
+	public void canAccessRemoteStatusAtHeight() {
+		// Arrange:
+		final RemoteLinks links = new RemoteLinks();
+
+		// Act:
+		final RemoteLink link1 = RemoteLinkFactory.activateRemoteHarvester(Utils.generateRandomAddress(), new BlockHeight(7));
+		final RemoteLink link2 = RemoteLinkFactory.activateHarvestingRemotely(Utils.generateRandomAddress(), new BlockHeight(9));
+		links.addLink(link1);
+		links.addLink(link2);
+
+		// Assert: getRemoteStatus uses *active* remote link
+		MatcherAssert.assertThat(links.getRemoteStatus(new BlockHeight(6)), IsEqual.equalTo(RemoteStatus.NOT_SET));
+		MatcherAssert.assertThat(links.getRemoteStatus(new BlockHeight(7)), IsEqual.equalTo(RemoteStatus.REMOTE_ACTIVATING));
+		MatcherAssert.assertThat(links.getRemoteStatus(new BlockHeight(8)), IsEqual.equalTo(RemoteStatus.REMOTE_ACTIVATING));
+		MatcherAssert.assertThat(links.getRemoteStatus(new BlockHeight(9)), IsEqual.equalTo(RemoteStatus.OWNER_ACTIVATING));
+		MatcherAssert.assertThat(links.getRemoteStatus(new BlockHeight(10)), IsEqual.equalTo(RemoteStatus.OWNER_ACTIVATING));
+	}
+
+	// endregion
+
 	// region copy
 
 	@Test


### PR DESCRIPTION
 problem: when (future) remote link is pending fixLessor
          findForwardedStateByAddress will use the future (not active) remote link for resolution
solution: update RemoteLinks to retrieve active (not current) remote link
          use height already passed into findForwardedStateByAddress to choose active link