### PR TITLE
[nis]: add local endpoint for querying historical mosaic supplies

### DIFF
--- a/nis/src/main/java/org/nem/nis/controller/MosaicDefinitionController.java
+++ b/nis/src/main/java/org/nem/nis/controller/MosaicDefinitionController.java
@@ -2,12 +2,13 @@ package org.nem.nis.controller;
 
 import org.nem.core.model.mosaic.*;
 import org.nem.core.model.namespace.NamespaceId;
+import org.nem.core.model.primitive.BlockHeight;
 import org.nem.core.model.ncc.*;
 import org.nem.core.serialization.SerializableList;
-import org.nem.nis.controller.annotations.ClientApi;
+import org.nem.nis.controller.annotations.*;
 import org.nem.nis.controller.requests.*;
 import org.nem.nis.dao.ReadOnlyMosaicDefinitionDao;
-import org.nem.nis.dbmodel.DbMosaicDefinition;
+import org.nem.nis.dbmodel.*;
 import org.nem.nis.mappers.NisDbModelToModelMapper;
 import org.nem.nis.service.MosaicInfoFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,6 +81,34 @@ public class MosaicDefinitionController {
 		}
 
 		return this.map(dbMosaicDefinition);
+	}
+
+	// endregion
+
+	// region getMosaicDefinitionWithSupply
+
+	/**
+	 * Gets the mosaic definition and supply for a given mosaic id at the specified height.
+	 *
+	 * @param builder The mosaic id builder.
+	 * @param heightBuilder The height builder.
+	 * @return The mosaic definition and supply pair (or empty if not found).
+	 */
+	@RequestMapping(value = "/local/mosaic/definition/supply", method = RequestMethod.GET)
+	@ClientApi
+	@TrustedApi
+	public SerializableList<MosaicDefinitionSupplyPair> getMosaicDefinitionWithSupply(final MosaicIdBuilder builder, final BlockHeightBuilder heightBuilder) {
+		final MosaicId mosaicId = builder.build();
+		final BlockHeight height = heightBuilder.build();
+
+		final DbMosaicDefinitionSupplyPair dbPair = this.mosaicDefinitionDao.getMosaicDefinitionWithSupply(mosaicId, height.getRaw());
+
+		final SerializableList<MosaicDefinitionSupplyPair> pairs = new SerializableList<>(1);
+		if (null != dbPair) {
+			pairs.add(new MosaicDefinitionSupplyPair(this.map(dbPair.getMosaicDefinition()), dbPair.getSupply()));
+		}
+
+		return pairs;
 	}
 
 	// endregion

--- a/nis/src/main/java/org/nem/nis/controller/requests/BlockHeightBuilder.java
+++ b/nis/src/main/java/org/nem/nis/controller/requests/BlockHeightBuilder.java
@@ -1,0 +1,29 @@
+package org.nem.nis.controller.requests;
+
+import org.nem.core.model.primitive.BlockHeight;
+import org.nem.core.utils.StringUtils;
+
+/**
+ * Builder that is used by Spring to create a BlockHeight from a GET request.
+ */
+public class BlockHeightBuilder {
+	private String blockHeight;
+
+	/**
+	 * Sets the block height.
+	 *
+	 * @param blockHeight The block height.
+	 */
+	public void setHeight(final String blockHeight) {
+		this.blockHeight = blockHeight;
+	}
+
+	/**
+	 * Creates a BlockHeight.
+	 *
+	 * @return The block height.
+	 */
+	public BlockHeight build() {
+		return new BlockHeight(StringUtils.isNullOrEmpty(this.blockHeight) ? Long.MAX_VALUE : Long.parseLong(this.blockHeight, 10));
+	}
+}

--- a/nis/src/main/java/org/nem/nis/dao/MosaicDefinitionDaoImpl.java
+++ b/nis/src/main/java/org/nem/nis/dao/MosaicDefinitionDaoImpl.java
@@ -4,8 +4,8 @@ import org.hibernate.*;
 import org.nem.core.model.Address;
 import org.nem.core.model.mosaic.MosaicId;
 import org.nem.core.model.namespace.NamespaceId;
-import org.nem.nis.dao.retrievers.MosaicDefinitionRetriever;
-import org.nem.nis.dbmodel.DbMosaicDefinition;
+import org.nem.nis.dao.retrievers.*;
+import org.nem.nis.dbmodel.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +16,7 @@ import java.util.*;
 public class MosaicDefinitionDaoImpl implements ReadOnlyMosaicDefinitionDao {
 	private final SessionFactory sessionFactory;
 	private final MosaicDefinitionRetriever retriever;
+	private final MosaicSupplyRetriever supplyRetriever;
 
 	/**
 	 * Creates a mosaic definition dao implementation.
@@ -24,7 +25,7 @@ public class MosaicDefinitionDaoImpl implements ReadOnlyMosaicDefinitionDao {
 	 */
 	@Autowired(required = true)
 	public MosaicDefinitionDaoImpl(final SessionFactory sessionFactory) {
-		this(sessionFactory, new MosaicDefinitionRetriever());
+		this(sessionFactory, new MosaicDefinitionRetriever(), new MosaicSupplyRetriever());
 	}
 
 	/**
@@ -32,10 +33,12 @@ public class MosaicDefinitionDaoImpl implements ReadOnlyMosaicDefinitionDao {
 	 *
 	 * @param sessionFactory The session factory.
 	 * @param retriever The mosaic retriever.
+	 * @param supplyRetriever The mosaic supply retriever.
 	 */
-	public MosaicDefinitionDaoImpl(final SessionFactory sessionFactory, final MosaicDefinitionRetriever retriever) {
+	public MosaicDefinitionDaoImpl(final SessionFactory sessionFactory, final MosaicDefinitionRetriever retriever, final MosaicSupplyRetriever supplyRetriever) {
 		this.sessionFactory = sessionFactory;
 		this.retriever = retriever;
+		this.supplyRetriever = supplyRetriever;
 	}
 
 	private Session getCurrentSession() {
@@ -46,6 +49,12 @@ public class MosaicDefinitionDaoImpl implements ReadOnlyMosaicDefinitionDao {
 	@Transactional(readOnly = true)
 	public DbMosaicDefinition getMosaicDefinition(final MosaicId mosaicId) {
 		return this.retriever.getMosaicDefinition(this.getCurrentSession(), mosaicId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public DbMosaicDefinitionSupplyPair getMosaicDefinitionWithSupply(final MosaicId mosaicId, final Long height) {
+		return this.supplyRetriever.getMosaicDefinitionWithSupply(this.getCurrentSession(), mosaicId, height);
 	}
 
 	@Override

--- a/nis/src/main/java/org/nem/nis/dao/ReadOnlyMosaicDefinitionDao.java
+++ b/nis/src/main/java/org/nem/nis/dao/ReadOnlyMosaicDefinitionDao.java
@@ -3,7 +3,7 @@ package org.nem.nis.dao;
 import org.nem.core.model.Address;
 import org.nem.core.model.mosaic.MosaicId;
 import org.nem.core.model.namespace.NamespaceId;
-import org.nem.nis.dbmodel.DbMosaicDefinition;
+import org.nem.nis.dbmodel.*;
 
 import java.util.Collection;
 
@@ -18,6 +18,15 @@ public interface ReadOnlyMosaicDefinitionDao {
 	 * @return The db mosaic definition.
 	 */
 	DbMosaicDefinition getMosaicDefinition(final MosaicId mosaicId);
+
+	/**
+	 * Gets a mosaic definition and its corresponding supply at a specified height.
+	 *
+	 * @param mosaicId The mosaic id.
+	 * @param height The search height.
+	 * @return The db mosaic definition and supply, if found. \c null otherwise.
+	 */
+	DbMosaicDefinitionSupplyPair getMosaicDefinitionWithSupply(final MosaicId mosaicId, final Long height);
 
 	/**
 	 * Gets all mosaic definitions for the specified account, optionally confined to a specified namespace. The search is limited by a given

--- a/nis/src/main/java/org/nem/nis/dao/retrievers/MosaicSupplyRetriever.java
+++ b/nis/src/main/java/org/nem/nis/dao/retrievers/MosaicSupplyRetriever.java
@@ -1,0 +1,113 @@
+package org.nem.nis.dao.retrievers;
+
+import org.hibernate.*;
+import org.hibernate.criterion.*;
+import org.nem.core.model.MosaicSupplyType;
+import org.nem.core.model.mosaic.MosaicId;
+import org.nem.core.model.primitive.*;
+import org.nem.nis.dao.*;
+import org.nem.nis.dbmodel.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Class for for retrieving mosaic supplies.
+ */
+public class MosaicSupplyRetriever {
+	/**
+	 * Gets a mosaic definition and its corresponding supply at a specified height.
+	 *
+	 * @param session The session.
+	 * @param mosaicId The mosaic id.
+	 * @param height The search height.
+	 * @return The db mosaic definition and supply, if found. \c null otherwise.
+	 */
+	public DbMosaicDefinitionSupplyPair getMosaicDefinitionWithSupply(final Session session, final MosaicId mosaicId, final Long height) {
+		final List<DbMosaicDefinitionCreationTransaction> creationTransactions = MosaicSupplyRetriever.queryCreationTransactions(session, mosaicId, height);
+
+		Long supply = 0L;
+		Long firstCreationHeight = 0L;
+		DbMosaicDefinition matchingMosaicDefinition = null;
+		final Collection<Long> dbMosaicDefinitionIds = new HashSet<>();
+		for (final DbMosaicDefinitionCreationTransaction transaction : creationTransactions) {
+			final DbMosaicDefinition mosaicDefinition = transaction.getMosaicDefinition();
+			if (null != matchingMosaicDefinition) {
+				if (!MosaicSupplyRetriever.areDefinitionsEqual(matchingMosaicDefinition, mosaicDefinition)) {
+					break;
+				}
+			} else {
+				final DbMosaicProperty mosaicProperty = MosaicSupplyRetriever.findPropertyByName(mosaicDefinition, "initialSupply");
+				supply = Long.parseLong(mosaicProperty.getValue(), 10);
+				matchingMosaicDefinition = mosaicDefinition;
+			}
+
+			firstCreationHeight = transaction.getBlock().getHeight();
+			dbMosaicDefinitionIds.add(mosaicDefinition.getId());
+		}
+
+		if (0L == firstCreationHeight)
+			return null;
+
+		final List<DbMosaicSupplyChangeTransaction> supplyChangeTransactions = MosaicSupplyRetriever.querySupplyChangeTransactions(
+			session, dbMosaicDefinitionIds, firstCreationHeight, height);
+
+		for (final DbMosaicSupplyChangeTransaction transaction : supplyChangeTransactions) {
+			if (MosaicSupplyType.Create.value() == transaction.getSupplyType()) {
+				supply += transaction.getQuantity();
+			} else {
+				supply -= transaction.getQuantity();
+			}
+		}
+
+		return new DbMosaicDefinitionSupplyPair(matchingMosaicDefinition, new Supply(supply));
+	}
+
+	private static List<DbMosaicDefinitionCreationTransaction> queryCreationTransactions(final Session session, final MosaicId mosaicId, final Long height) {
+		final Criteria creationTransactionsCriteria = session.createCriteria(DbMosaicDefinitionCreationTransaction.class, "transaction") // preserve-newline
+				.setFetchMode("sender", FetchMode.JOIN) // preserve-newline
+				.createAlias("transaction.block", "block") // preserve-newline
+				.createAlias("transaction.mosaicDefinition", "mosaicDefinition") // preserve-newline
+				.add(Restrictions.eq("mosaicDefinition.namespaceId", mosaicId.getNamespaceId().toString())) // preserve-newline
+				.add(Restrictions.eq("mosaicDefinition.name", mosaicId.getName())) // preserve-newline
+				.add(Restrictions.le("block.height", height)) // preserve-newline
+				.addOrder(Order.desc("block.height")) // preserve-newline
+				.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
+		return HibernateUtils.listAndCast(creationTransactionsCriteria);
+	}
+
+	private static List<DbMosaicSupplyChangeTransaction> querySupplyChangeTransactions(final Session session,
+			final Collection<Long> dbMosaicDefinitionIds, final Long startHeight, final Long endHeight) {
+		final Criteria supplyChangeTransactionCriteria = session.createCriteria(DbMosaicSupplyChangeTransaction.class, "transaction") // preserve-newline
+				.setFetchMode("sender", FetchMode.JOIN) // preserve-newline
+				.createAlias("transaction.block", "block") // preserve-newline
+				.add(Restrictions.in("dbMosaicId", dbMosaicDefinitionIds)) // preserve-newline
+				.add(Restrictions.ge("block.height", startHeight)) // preserve-newline
+				.add(Restrictions.le("block.height", endHeight)) // preserve-newline
+				.addOrder(Order.desc("block.height")) // preserve-newline
+				.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
+		return HibernateUtils.listAndCast(supplyChangeTransactionCriteria);
+	}
+
+	private static DbMosaicProperty findPropertyByName(final DbMosaicDefinition mosaicDefinition, final String name) {
+		return mosaicDefinition.getProperties().stream().filter(property -> property.getName().equals(name)).findFirst().get();
+	}
+
+	private static Boolean areDefinitionsEqual(final DbMosaicDefinition lhs, final DbMosaicDefinition rhs) {
+		// check mosaic properties
+		for (final DbMosaicProperty property : lhs.getProperties()) {
+			if (!property.getValue().equals(MosaicSupplyRetriever.findPropertyByName(rhs, property.getName()).getValue())) {
+				return false;
+			}
+		}
+
+		// check other properties
+		return
+			lhs.getCreator().getId() == rhs.getCreator().getId()
+			&& lhs.getFeeType() == rhs.getFeeType()
+			&& lhs.getFeeDbMosaicId() == rhs.getFeeDbMosaicId()
+			&& lhs.getFeeQuantity() == rhs.getFeeQuantity()
+			&& (null == lhs.getFeeRecipient()) == (null == rhs.getFeeRecipient())
+			&& (null == lhs.getFeeRecipient() || lhs.getFeeRecipient().getId() == rhs.getFeeRecipient().getId());
+	}
+}

--- a/nis/src/main/java/org/nem/nis/dbmodel/DbMosaicDefinitionSupplyPair.java
+++ b/nis/src/main/java/org/nem/nis/dbmodel/DbMosaicDefinitionSupplyPair.java
@@ -1,0 +1,40 @@
+package org.nem.nis.dbmodel;
+
+import org.nem.core.model.primitive.Supply;
+
+/**
+ * Pair of DbMosaicDefinition and Supply.
+ */
+public class DbMosaicDefinitionSupplyPair {
+	private DbMosaicDefinition mosaicDefinition;
+	private Supply supply;
+
+	/**
+	 * Creates a DbMosaicDefinition and Supply pair.
+	 *
+	 * @param mosaicDefinition Mosaic definition.
+	 * @param supply Mosaic supply.
+	 */
+	public DbMosaicDefinitionSupplyPair(DbMosaicDefinition mosaicDefinition, Supply supply) {
+		this.mosaicDefinition = mosaicDefinition;
+		this.supply = supply;
+	}
+
+	/**
+	 * Gets mosaic definition.
+	 *
+	 * @return Mosaic definition.
+	 */
+	public DbMosaicDefinition getMosaicDefinition() {
+		return this.mosaicDefinition;
+	}
+
+	/**
+	 * Gets mosaic supply.
+	 *
+	 * @return Mosaic supply.
+	 */
+	public Supply getSupply() {
+		return this.supply;
+	}
+};

--- a/nis/src/test/java/org/nem/nis/controller/requests/BlockHeightBuilderTest.java
+++ b/nis/src/test/java/org/nem/nis/controller/requests/BlockHeightBuilderTest.java
@@ -1,0 +1,34 @@
+package org.nem.nis.controller.requests;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.*;
+import org.nem.core.model.primitive.BlockHeight;
+
+public class BlockHeightBuilderTest {
+
+	@Test
+	public void blockHeightCanBeBuilt() {
+		// Arrange:
+		final BlockHeightBuilder builder = new BlockHeightBuilder();
+
+		// Act:
+		builder.setHeight("12345");
+		final BlockHeight blockHeight = builder.build();
+
+		// Assert:
+		MatcherAssert.assertThat(blockHeight, IsEqual.equalTo(new BlockHeight(12345)));
+	}
+
+	@Test
+	public void blockHeightCanBeBuiltWhenUnset() {
+		// Arrange:
+		final BlockHeightBuilder builder = new BlockHeightBuilder();
+
+		// Act:
+		final BlockHeight blockHeight = builder.build();
+
+		// Assert:
+		MatcherAssert.assertThat(blockHeight, IsEqual.equalTo(new BlockHeight(Long.MAX_VALUE)));
+	}
+}

--- a/nis/src/test/java/org/nem/nis/dao/retrievers/MosaicSupplyRetrieverTest.java
+++ b/nis/src/test/java/org/nem/nis/dao/retrievers/MosaicSupplyRetrieverTest.java
@@ -1,0 +1,193 @@
+package org.nem.nis.dao.retrievers;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.*;
+import org.hibernate.*;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.nem.core.crypto.Hash;
+import org.nem.core.model.*;
+import org.nem.core.model.Transaction;
+import org.nem.core.model.mosaic.*;
+import org.nem.core.model.namespace.*;
+import org.nem.core.model.primitive.*;
+import org.nem.core.test.*;
+import org.nem.core.time.TimeInstant;
+import org.nem.nis.cache.*;
+import org.nem.nis.dao.*;
+import org.nem.nis.dbmodel.*;
+import org.nem.nis.mappers.AccountDaoLookupAdapter;
+import org.nem.nis.state.AccountState;
+import org.nem.nis.test.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.stream.*;
+
+@ContextConfiguration(classes = TestConf.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+public class MosaicSupplyRetrieverTest {
+	// region auto wiring
+
+	@Autowired
+	private SessionFactory sessionFactory;
+
+	private Session session;
+
+	@Autowired
+	private AccountDao accountDao;
+
+	@Autowired
+	private BlockDao blockDao;
+
+	@Autowired
+	private MosaicIdCache mosaicIdCache;
+
+	// endregion
+
+	// region test setup
+
+	@Before
+	public void createDb() {
+		this.session = this.sessionFactory.openSession();
+		this.setupBlocks();
+	}
+
+	@After
+	public void destroyDb() {
+		if (null != this.session) {
+			DbTestUtils.dbCleanup(this.session);
+			this.session.close();
+		}
+
+		this.mosaicIdCache.clear();
+		Utils.resetGlobals();
+	}
+
+	private Transaction createCreationTransaction(final Account account, final String namespaceId, final String name, final String description, final Long supply) {
+		final MosaicId mosaicId = Utils.createMosaicId(namespaceId, name);
+		final MosaicDefinition mosaicDefinition = new MosaicDefinition(account, mosaicId, new MosaicDescriptor(description),
+				Utils.createMosaicPropertiesWithInitialSupply(supply), null);
+		final Transaction transaction = new MosaicDefinitionCreationTransaction(new TimeInstant(1), account, mosaicDefinition,
+				Utils.generateRandomAccount(), Amount.fromNem(50_000));
+		transaction.sign();
+		return transaction;
+	}
+
+	private Transaction createSupplyChangeTransaction(final Account account, final String namespaceId, final String name, final MosaicSupplyType supplyType, final Long supply) {
+		final MosaicId mosaicId = Utils.createMosaicId(namespaceId, name);
+		final Transaction transaction = new MosaicSupplyChangeTransaction(new TimeInstant(1), account, mosaicId, supplyType, Supply.fromValue(supply));
+		transaction.sign();
+		return transaction;
+	}
+
+	private void saveDbBlock(final Long height, final Transaction transaction) {
+		final List<Transaction> transactions = new ArrayList<>();
+		transactions.add(transaction);
+		this.saveDbBlock(height, transactions);
+	}
+
+	private void saveDbBlock(final Long height, final Collection<Transaction> transactions) {
+		final Block block = NisUtils.createRandomBlockWithHeight(height);
+
+		block.addTransactions(transactions);
+		block.sign();
+
+		final DbBlock dbBlock = MapperUtils.toDbModel(block, new AccountDaoLookupAdapter(this.accountDao), this.mosaicIdCache);
+		this.blockDao.save(dbBlock);
+	}
+
+	private void setupBlocks() {
+		final Account signer = Utils.generateRandomAccount();
+		this.saveDbBlock(10L, this.createCreationTransaction(signer, "fox", "tokens", "cool fox tokens", 1000L)); // supply change (create)
+
+		this.saveDbBlock(20L, this.createCreationTransaction(signer, "fox", "nuggets", "nice fox tokens", 2000L)); // other token
+		this.saveDbBlock(25L, this.createSupplyChangeTransaction(signer, "fox", "nuggets", MosaicSupplyType.Create, 100L));
+
+		this.saveDbBlock(30L, this.createCreationTransaction(signer, "bobcat", "tokens", "nice bobcat tokens", 3000L)); // other token
+		this.saveDbBlock(35L, this.createSupplyChangeTransaction(signer, "bobcat", "tokens", MosaicSupplyType.Create, 200L));
+
+		this.saveDbBlock(40L, this.createCreationTransaction(signer, "fox", "tokens", "cool fox tokens", 4000L)); // supply change (reset)
+		this.saveDbBlock(45L, this.createSupplyChangeTransaction(signer, "fox", "tokens", MosaicSupplyType.Create, 900L));
+		this.saveDbBlock(50L, this.createCreationTransaction(signer, "fox", "tokens", "cool fox tokens", 5000L)); // supply change (reset)
+		this.saveDbBlock(55L, this.createSupplyChangeTransaction(signer, "fox", "tokens", MosaicSupplyType.Create, 800L));
+		this.saveDbBlock(60L, this.createCreationTransaction(signer, "fox", "tokens", "coolest fox tokens", 5000L)); // description only change (reuse)
+		this.saveDbBlock(65L, this.createSupplyChangeTransaction(signer, "fox", "tokens", MosaicSupplyType.Delete, 700L));
+	}
+
+	// endregion
+
+	// region tests - getMosaicDefinitionWithSupply
+
+	private Long getInitialBalancePropertyValue(final DbMosaicDefinition mosaicDefinition) {
+		final DbMosaicProperty mosaicProperty = mosaicDefinition.getProperties().stream()
+				.filter(property -> property.getName() == "initialSupply")
+				.findFirst()
+				.get();
+		return Long.parseLong(mosaicProperty.getValue(), 10);
+	}
+
+	void assertFoxTokensSupplyAt(final Long height, final Long expectedInitialSupply, final Long expectedSupply) {
+		// Arrange:
+		final MosaicSupplyRetriever retriever = new MosaicSupplyRetriever();
+
+		// Act:
+		final DbMosaicDefinitionSupplyPair pair = retriever.getMosaicDefinitionWithSupply(this.session, Utils.createMosaicId("fox", "tokens"), height);
+
+		// Assert:
+		MatcherAssert.assertThat(pair, IsNot.not(IsEqual.equalTo(null)));
+		MatcherAssert.assertThat(getInitialBalancePropertyValue(pair.getMosaicDefinition()), IsEqual.equalTo(expectedInitialSupply));
+		MatcherAssert.assertThat(pair.getSupply(), IsEqual.equalTo(new Supply(expectedSupply)));
+	}
+
+	@Test
+	public void getSupplyReturnsNullWhenNoMatchingMosaicDefinition() {
+		// Arrange:
+		final MosaicSupplyRetriever retriever = new MosaicSupplyRetriever();
+
+		// Act:
+		final DbMosaicDefinitionSupplyPair pair = retriever.getMosaicDefinitionWithSupply(this.session, Utils.createMosaicId("fox", "tokens"), 9L);
+
+		// Assert:
+		MatcherAssert.assertThat(pair, IsEqual.equalTo(null));
+	}
+
+	@Test
+	public void getSupplyReturnsMostRecentSupplyWhenNoHeightConstraint() {
+		this.assertFoxTokensSupplyAt(Long.MAX_VALUE, 5000L, 5100L);
+	}
+
+	@Test
+	public void getSupplyReturnsHistoricalSupplyWhenHeightConstraint() {
+		this.assertFoxTokensSupplyAt(10L, 1000L, 1000L); // creation = 1000
+		this.assertFoxTokensSupplyAt(11L, 1000L, 1000L);
+		this.assertFoxTokensSupplyAt(39L, 1000L, 1000L);
+
+		this.assertFoxTokensSupplyAt(40L, 4000L, 4000L); // creation = 4000
+		this.assertFoxTokensSupplyAt(41L, 4000L, 4000L);
+		this.assertFoxTokensSupplyAt(44L, 4000L, 4000L);
+
+		this.assertFoxTokensSupplyAt(45L, 4000L, 4900L); // supply += 900
+		this.assertFoxTokensSupplyAt(46L, 4000L, 4900L);
+		this.assertFoxTokensSupplyAt(49L, 4000L, 4900L);
+
+		this.assertFoxTokensSupplyAt(50L, 5000L, 5000L); // creation = 5000
+		this.assertFoxTokensSupplyAt(51L, 5000L, 5000L);
+		this.assertFoxTokensSupplyAt(54L, 5000L, 5000L);
+
+		this.assertFoxTokensSupplyAt(55L, 5000L, 5800L); // supply += 800
+		this.assertFoxTokensSupplyAt(56L, 5000L, 5800L);
+		this.assertFoxTokensSupplyAt(59L, 5000L, 5800L);
+		this.assertFoxTokensSupplyAt(60L, 5000L, 5800L); // creation [ignore]
+		this.assertFoxTokensSupplyAt(61L, 5000L, 5800L);
+		this.assertFoxTokensSupplyAt(64L, 5000L, 5800L);
+
+		this.assertFoxTokensSupplyAt(65L, 5000L, 5100L); // supply -= 700
+		this.assertFoxTokensSupplyAt(66L, 5000L, 5100L);
+	}
+
+	// endregion
+}

--- a/nis/src/test/java/org/nem/nis/dbmodel/DbMosaicDefinitionSupplyPairTest.java
+++ b/nis/src/test/java/org/nem/nis/dbmodel/DbMosaicDefinitionSupplyPairTest.java
@@ -1,0 +1,25 @@
+package org.nem.nis.dbmodel;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.*;
+import org.junit.*;
+import org.nem.core.model.primitive.Supply;
+
+import java.util.*;
+
+public class DbMosaicDefinitionSupplyPairTest {
+
+	@Test
+	public void canCreatePair() {
+		// Arrange:
+		final DbMosaicDefinition mosaicDefinition = new DbMosaicDefinition();
+
+		// Act:
+		final DbMosaicDefinitionSupplyPair pair = new DbMosaicDefinitionSupplyPair(mosaicDefinition, new Supply(123L));
+
+		// Assert:
+		MatcherAssert.assertThat(pair.getMosaicDefinition(), IsEqual.equalTo(mosaicDefinition));
+		MatcherAssert.assertThat(pair.getSupply(), IsEqual.equalTo(new Supply(123L)));
+	}
+}


### PR DESCRIPTION
 problem: historical supplies are needed to properly handle redefined mosaics
solution: add endpoint (local-only) endpoint