### PR TITLE
[nis]: add new TRACK_EXPIRED_MOSAICS node feature

### DIFF
--- a/core/src/main/java/org/nem/core/node/NodeFeature.java
+++ b/core/src/main/java/org/nem/core/node/NodeFeature.java
@@ -8,19 +8,19 @@ import java.util.*;
 public enum NodeFeature {
 
 	/**
-	 * The node supports looking up transactions by hash.
+	 * Node supports looking up transactions by hash.
 	 */
 	TRANSACTION_HASH_LOOKUP(0x00000001),
 
 	/**
-	 * The node supports supplying historical account data.
+	 * Node supports supplying historical account data.
 	 */
 	HISTORICAL_ACCOUNT_DATA(0x0000002),
 
 	/**
-	 * A placeholder value (should be replaced when there is another feature).
+	 * Node supports tracking expired mosaics.
 	 */
-	PLACEHOLDER2(0x0000004);
+	TRACK_EXPIRED_MOSAICS(0x0000004);
 
 	private final int value;
 

--- a/core/src/test/java/org/nem/core/node/NodeFeatureTest.java
+++ b/core/src/test/java/org/nem/core/node/NodeFeatureTest.java
@@ -19,7 +19,7 @@ public class NodeFeatureTest {
 			{
 				this.put("TRANSACTION_HASH_LOOKUP", NodeFeature.TRANSACTION_HASH_LOOKUP);
 				this.put("HISTORICAL_ACCOUNT_DATA", NodeFeature.HISTORICAL_ACCOUNT_DATA);
-				this.put("PLACEHOLDER2", NodeFeature.PLACEHOLDER2);
+				this.put("TRACK_EXPIRED_MOSAICS", NodeFeature.TRACK_EXPIRED_MOSAICS);
 			}
 		};
 
@@ -75,7 +75,7 @@ public class NodeFeatureTest {
 	@Test
 	public void canBitwiseOrTogetherMultipleFeatures() {
 		// Act:
-		final int value = NodeFeature.or(NodeFeature.TRANSACTION_HASH_LOOKUP, NodeFeature.PLACEHOLDER2);
+		final int value = NodeFeature.or(NodeFeature.TRANSACTION_HASH_LOOKUP, NodeFeature.TRACK_EXPIRED_MOSAICS);
 
 		// Assert:
 		MatcherAssert.assertThat(value, IsEqual.equalTo(5));
@@ -108,7 +108,7 @@ public class NodeFeatureTest {
 
 		// Assert:
 		MatcherAssert.assertThat(features, IsEqual.equalTo(new NodeFeature[]{
-				NodeFeature.TRANSACTION_HASH_LOOKUP, NodeFeature.PLACEHOLDER2
+				NodeFeature.TRANSACTION_HASH_LOOKUP, NodeFeature.TRACK_EXPIRED_MOSAICS
 		}));
 	}
 

--- a/nis/src/main/java/org/nem/nis/NisMain.java
+++ b/nis/src/main/java/org/nem/nis/NisMain.java
@@ -146,6 +146,10 @@ public class NisMain {
 			options.add(ObserverOption.NoIncrementalPoi);
 		}
 
+		if (!config.isFeatureSupported(NodeFeature.TRACK_EXPIRED_MOSAICS)) {
+			options.add(ObserverOption.NoExpiredMosaicTracking);
+		}
+
 		final BlockChainConfiguration blockChainConfiguration = config.getBlockChainConfiguration();
 		if (blockChainConfiguration.isBlockChainFeatureSupported(BlockChainFeature.PROOF_OF_STAKE)) {
 			options.add(ObserverOption.NoOutlinkObserver);

--- a/nis/src/main/java/org/nem/nis/cache/DeepCopyableCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/DeepCopyableCache.java
@@ -1,0 +1,15 @@
+package org.nem.nis.cache;
+
+/**
+ * A cache that can be deep copied.
+ */
+@SuppressWarnings("rawtypes")
+public interface DeepCopyableCache<TDerived extends DeepCopyableCache> extends CopyableCache<TDerived> {
+
+	/**
+	 * Creates a deep copy of this cache.
+	 *
+	 * @return A deep copy of this cache.
+	 */
+	TDerived deepCopy();
+}

--- a/nis/src/main/java/org/nem/nis/cache/DefaultExpiredMosaicCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/DefaultExpiredMosaicCache.java
@@ -1,0 +1,117 @@
+package org.nem.nis.cache;
+
+import org.nem.core.model.mosaic.*;
+import org.nem.core.model.primitive.*;
+import org.nem.nis.cache.delta.*;
+import org.nem.nis.state.ReadOnlyMosaicBalances;
+
+import java.util.*;
+
+/**
+ * Default implementation of an expired mosaic cache.
+ */
+public class DefaultExpiredMosaicCache implements ExpiredMosaicCache, DeepCopyableCache<DefaultExpiredMosaicCache>, CommittableCache {
+	private final MutableObjectAwareDeltaMap<BlockHeight, ExpiredMosaicBlockGroup> map;
+	private boolean isCopy = false;
+
+	public DefaultExpiredMosaicCache() {
+		this(new MutableObjectAwareDeltaMap<>(100));
+	}
+
+	private DefaultExpiredMosaicCache(final MutableObjectAwareDeltaMap<BlockHeight, ExpiredMosaicBlockGroup> map) {
+		this.map = map;
+	}
+
+	@Override
+	public int size() {
+		return this.map.size();
+	}
+
+	@Override
+	public int deepSize() {
+		return this.map.readOnlyEntrySet().stream().map(Map.Entry::getValue).map(group -> group.expiredMosaicsCount()).reduce(0, Integer::sum);
+	}
+
+	@Override
+	public Collection<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> findExpirationsAtHeight(BlockHeight height) {
+		final ExpiredMosaicBlockGroup group = this.map.getOrDefault(height, null);
+		return null == group ? new ArrayList<>() : group.getAll();
+	}
+
+	@Override
+	public void addExpiration(final BlockHeight height, final MosaicId mosaicId, final ReadOnlyMosaicBalances balances) {
+		if (!this.map.containsKey(height)) {
+			this.map.put(height, new ExpiredMosaicBlockGroup());
+		}
+
+		this.map.get(height).addExpiredMosaic(mosaicId, balances);
+	}
+
+	@Override
+	public void removeAll(final BlockHeight height) {
+		this.map.remove(height);
+	}
+
+	// region DeepCopyableCache
+
+	@Override
+	public void shallowCopyTo(final DefaultExpiredMosaicCache rhs) {
+		this.map.shallowCopyTo(rhs.map);
+	}
+
+	@Override
+	public DefaultExpiredMosaicCache copy() {
+		if (this.isCopy) {
+			throw new IllegalStateException("nested copies are currently not allowed");
+		}
+
+		// note that this is not copying at all
+		final DefaultExpiredMosaicCache copy = new DefaultExpiredMosaicCache(this.map.rebase());
+		copy.isCopy = true;
+		return copy;
+	}
+
+	@Override
+	public DefaultExpiredMosaicCache deepCopy() {
+		return new DefaultExpiredMosaicCache(this.map.deepCopy());
+	}
+
+	// endregion
+
+	// region CommitableCache
+
+	@Override
+	public void commit() {
+		this.map.commit();
+	}
+
+	// endregion
+
+	// region ExpiredMosaicBlockGroup
+
+	private static class ExpiredMosaicBlockGroup implements Copyable<ExpiredMosaicBlockGroup> {
+		private final Map<MosaicId, ReadOnlyMosaicBalances> expiredMosaics = new HashMap<>();
+
+		public int expiredMosaicsCount() {
+			return this.expiredMosaics.size();
+		}
+
+		public Collection<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> getAll() {
+			return this.expiredMosaics.entrySet();
+		}
+
+		public void addExpiredMosaic(final MosaicId mosaicId, final ReadOnlyMosaicBalances balances) {
+			this.expiredMosaics.put(mosaicId, balances);
+		}
+
+		@Override
+		public ExpiredMosaicBlockGroup copy() {
+			// notice that both keys and values are immutable, so no additional copies are needed
+			final ExpiredMosaicBlockGroup copy = new ExpiredMosaicBlockGroup();
+			this.expiredMosaics.entrySet().forEach(e -> copy.expiredMosaics.put(e.getKey(), e.getValue()));
+			return copy;
+		}
+	}
+
+	// endregion
+};

--- a/nis/src/main/java/org/nem/nis/cache/DefaultNisCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/DefaultNisCache.java
@@ -9,6 +9,7 @@ public class DefaultNisCache implements ReadOnlyNisCache {
 	private final SynchronizedPoxFacade poxFacade;
 	private final SynchronizedHashCache transactionHashCache;
 	private final SynchronizedNamespaceCache namespaceCache;
+	private final SynchronizedExpiredMosaicCache expiredMosaicCache;
 
 	/**
 	 * Creates a NIS cache from an existing account cache, a pox facade and a transaction hash cache.
@@ -18,15 +19,17 @@ public class DefaultNisCache implements ReadOnlyNisCache {
 	 * @param poxFacade The pox facade.
 	 * @param transactionHashCache The cache of transaction hashes.
 	 * @param namespaceCache The namespace cache.
+	 * @param expiredMosaicCache The expired mosaic cache.
 	 */
 	public DefaultNisCache(final SynchronizedAccountCache accountCache, final SynchronizedAccountStateCache accountStateCache,
 			final SynchronizedPoxFacade poxFacade, final SynchronizedHashCache transactionHashCache,
-			final SynchronizedNamespaceCache namespaceCache) {
+			final SynchronizedNamespaceCache namespaceCache, final SynchronizedExpiredMosaicCache expiredMosaicCache) {
 		this.accountCache = accountCache;
 		this.accountStateCache = accountStateCache;
 		this.poxFacade = poxFacade;
 		this.transactionHashCache = transactionHashCache;
 		this.namespaceCache = namespaceCache;
+		this.expiredMosaicCache = expiredMosaicCache;
 	}
 
 	@Override
@@ -55,6 +58,11 @@ public class DefaultNisCache implements ReadOnlyNisCache {
 	}
 
 	@Override
+	public ReadOnlyExpiredMosaicCache getExpiredMosaicCache() {
+		return this.expiredMosaicCache;
+	}
+
+	@Override
 	public NisCache copy() {
 		return new DefaultNisCacheCopy(this);
 	}
@@ -66,7 +74,7 @@ public class DefaultNisCache implements ReadOnlyNisCache {
 	 */
 	public DefaultNisCache deepCopy() {
 		return new DefaultNisCache(this.accountCache.deepCopy(), this.accountStateCache.deepCopy(), this.poxFacade.copy(),
-				this.transactionHashCache.deepCopy(), this.namespaceCache.deepCopy());
+				this.transactionHashCache.deepCopy(), this.namespaceCache.deepCopy(), this.expiredMosaicCache.deepCopy());
 	}
 
 	private static class DefaultNisCacheCopy implements NisCache {
@@ -76,6 +84,7 @@ public class DefaultNisCache implements ReadOnlyNisCache {
 		private final SynchronizedPoxFacade poxFacade;
 		private final SynchronizedHashCache transactionHashCache;
 		private final SynchronizedNamespaceCache namespaceCache;
+		private final SynchronizedExpiredMosaicCache expiredMosaicCache;
 
 		private DefaultNisCacheCopy(final DefaultNisCache cache) {
 			this.cache = cache;
@@ -84,6 +93,7 @@ public class DefaultNisCache implements ReadOnlyNisCache {
 			this.poxFacade = cache.poxFacade.copy();
 			this.transactionHashCache = cache.transactionHashCache.copy();
 			this.namespaceCache = cache.namespaceCache.copy();
+			this.expiredMosaicCache = cache.expiredMosaicCache.copy();
 		}
 
 		@Override
@@ -112,6 +122,11 @@ public class DefaultNisCache implements ReadOnlyNisCache {
 		}
 
 		@Override
+		public ExpiredMosaicCache getExpiredMosaicCache() {
+			return this.expiredMosaicCache;
+		}
+
+		@Override
 		public NisCache copy() {
 			throw new IllegalStateException("nested copies are not currently allowed");
 		}
@@ -123,6 +138,7 @@ public class DefaultNisCache implements ReadOnlyNisCache {
 			this.poxFacade.shallowCopyTo(this.cache.poxFacade);
 			this.transactionHashCache.commit();
 			this.namespaceCache.commit();
+			this.expiredMosaicCache.commit();
 		}
 	}
 }

--- a/nis/src/main/java/org/nem/nis/cache/ExpiredMosaicCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/ExpiredMosaicCache.java
@@ -1,0 +1,26 @@
+package org.nem.nis.cache;
+
+import org.nem.core.model.mosaic.MosaicId;
+import org.nem.core.model.primitive.BlockHeight;
+import org.nem.nis.state.ReadOnlyMosaicBalances;
+
+/**
+ * An expired mosaic cache containing information about mosaics that were zeroed upon expiration.
+ */
+public interface ExpiredMosaicCache extends ReadOnlyExpiredMosaicCache {
+	/**
+	 * Adds a mosaic expiration.
+	 *
+	 * @param height Height of expiration.
+	 * @param mosaicId Id of expiring mosaic.
+	 * @param balances Expiring mosaic balances.
+	 */
+	void addExpiration(final BlockHeight height, final MosaicId mosaicId, final ReadOnlyMosaicBalances balances);
+
+	/**
+	 * Removes all expirations at the specified height.
+	 *
+	 * @param height Height of expiration.
+	 */
+	void removeAll(final BlockHeight height);
+}

--- a/nis/src/main/java/org/nem/nis/cache/NisCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/NisCache.java
@@ -41,6 +41,13 @@ public interface NisCache extends ReadOnlyNisCache {
 	NamespaceCache getNamespaceCache();
 
 	/**
+	 * Gets the expired mosaic cache.
+	 *
+	 * @return The expired mosaic cache.
+	 */
+	ExpiredMosaicCache getExpiredMosaicCache();
+
+	/**
 	 * Commits all changes to the "real" cache.
 	 */
 	void commit();

--- a/nis/src/main/java/org/nem/nis/cache/ReadOnlyExpiredMosaicCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/ReadOnlyExpiredMosaicCache.java
@@ -1,0 +1,31 @@
+package org.nem.nis.cache;
+
+import org.nem.core.model.mosaic.MosaicId;
+import org.nem.core.model.primitive.BlockHeight;
+import org.nem.nis.state.ReadOnlyMosaicBalances;
+
+import java.util.*;
+
+public interface ReadOnlyExpiredMosaicCache {
+	/**
+	 * Gets the number of heights with mosaic expirations.
+	 *
+	 * @return Number of heights with mosaic expirations.
+	 */
+	int size();
+
+	/**
+	 * Gets the number of mosaic expirations across all heights.
+	 *
+	 * @return Number of mosaic expirations across all heights.
+	 */
+	int deepSize();
+
+	/**
+	 * Finds all mosaic expirations at specified height.
+	 *
+	 * @param height Height of expiration.
+	 * @return All expiring mosaics at height.
+	 */
+	Collection<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> findExpirationsAtHeight(BlockHeight height);
+}

--- a/nis/src/main/java/org/nem/nis/cache/ReadOnlyNisCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/ReadOnlyNisCache.java
@@ -41,6 +41,13 @@ public interface ReadOnlyNisCache {
 	ReadOnlyNamespaceCache getNamespaceCache();
 
 	/**
+	 * Gets the expired mosaic cache.
+	 *
+	 * @return The expired mosaic cache.
+	 */
+	ReadOnlyExpiredMosaicCache getExpiredMosaicCache();
+
+	/**
 	 * Creates a mutable copy of this NIS cache.
 	 *
 	 * @return The copy.

--- a/nis/src/main/java/org/nem/nis/cache/SynchronizedExpiredMosaicCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/SynchronizedExpiredMosaicCache.java
@@ -1,0 +1,87 @@
+package org.nem.nis.cache;
+
+import org.nem.core.model.mosaic.*;
+import org.nem.core.model.primitive.*;
+import org.nem.nis.state.ReadOnlyMosaicBalances;
+
+import java.util.*;
+
+/**
+ * A synchronized ExpiredMosaicCache implementation.
+ */
+public class SynchronizedExpiredMosaicCache implements ExpiredMosaicCache, DeepCopyableCache<SynchronizedExpiredMosaicCache>, CommittableCache {
+	private final DefaultExpiredMosaicCache cache;
+	private final Object lock = new Object();
+
+	/**
+	 * Creates a new cache.
+	 *
+	 * @param cache Expired moasaic cache.
+	 */
+	public SynchronizedExpiredMosaicCache(final DefaultExpiredMosaicCache cache) {
+		this.cache = cache;
+	}
+
+	@Override
+	public int size() {
+		synchronized (this.lock) {
+			return this.cache.size();
+		}
+	}
+
+	@Override
+	public int deepSize() {
+		synchronized (this.lock) {
+			return this.cache.deepSize();
+		}
+	}
+
+	@Override
+	public Collection<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> findExpirationsAtHeight(BlockHeight height) {
+		synchronized (this.lock) {
+			return this.cache.findExpirationsAtHeight(height);
+		}
+	}
+
+	@Override
+	public void addExpiration(final BlockHeight height, final MosaicId mosaicId, final ReadOnlyMosaicBalances balances) {
+		synchronized (this.lock) {
+			this.cache.addExpiration(height, mosaicId, balances);
+		}
+	}
+
+	@Override
+	public void removeAll(final BlockHeight height) {
+		synchronized (this.lock) {
+			this.cache.removeAll(height);
+		}
+	}
+
+	@Override
+	public void shallowCopyTo(final SynchronizedExpiredMosaicCache rhs) {
+		synchronized (rhs.lock) {
+			this.cache.shallowCopyTo(rhs.cache);
+		}
+	}
+
+	@Override
+	public SynchronizedExpiredMosaicCache copy() {
+		synchronized (this.lock) {
+			return new SynchronizedExpiredMosaicCache(this.cache.copy());
+		}
+	}
+
+	@Override
+	public SynchronizedExpiredMosaicCache deepCopy() {
+		synchronized (this.lock) {
+			return new SynchronizedExpiredMosaicCache(this.cache.deepCopy());
+		}
+	}
+
+	@Override
+	public void commit() {
+		synchronized (this.lock) {
+			this.cache.commit();
+		}
+	}
+}

--- a/nis/src/main/java/org/nem/nis/controller/ExpiredMosaicController.java
+++ b/nis/src/main/java/org/nem/nis/controller/ExpiredMosaicController.java
@@ -1,0 +1,60 @@
+package org.nem.nis.controller;
+
+import org.nem.core.model.mosaic.*;
+import org.nem.core.model.primitive.*;
+import org.nem.core.node.NodeFeature;
+import org.nem.core.serialization.SerializableList;
+import org.nem.specific.deploy.NisConfiguration;
+import org.nem.nis.cache.*;
+import org.nem.nis.controller.annotations.*;
+import org.nem.nis.controller.requests.BlockHeightBuilder;
+import org.nem.nis.controller.viewmodels.ExpiredMosaicViewModel;
+
+import org.nem.nis.state.ReadOnlyMosaicBalances;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+/**
+ * REST expired mosaic controller.
+ */
+@RestController
+public class ExpiredMosaicController {
+	private final NisConfiguration nisConfiguration;
+	private final ReadOnlyExpiredMosaicCache expiredMosaicCache;
+
+	@Autowired(required = true)
+	ExpiredMosaicController(final NisConfiguration nisConfiguration, final ReadOnlyExpiredMosaicCache expiredMosaicCache) {
+		this.nisConfiguration = nisConfiguration;
+		this.expiredMosaicCache = expiredMosaicCache;
+	}
+
+	// region expiredMosaics
+
+	/**
+	 * Gets the expired mosaics at the specified height.
+	 *
+	 * @param heightBuilder The height builder.
+	 * @return The expired mosaics (or empty if not found).
+	 */
+	@RequestMapping(value = "/local/mosaics/expired", method = RequestMethod.GET)
+	@ClientApi
+	@TrustedApi
+	public SerializableList<ExpiredMosaicViewModel> expiredMosaics(final BlockHeightBuilder heightBuilder) {
+		if (!this.nisConfiguration.isFeatureSupported(NodeFeature.TRACK_EXPIRED_MOSAICS)) {
+			throw new UnsupportedOperationException("this node does not support tracking expired mosaics");
+		}
+
+		final BlockHeight height = heightBuilder.build();
+		final Collection<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> expirations = this.expiredMosaicCache.findExpirationsAtHeight(height);
+		return new SerializableList<>(
+			expirations.stream()
+				.map(pair -> new ExpiredMosaicViewModel(pair.getKey(), pair.getValue()))
+				.collect(Collectors.toList())
+		);
+	}
+
+	// endregion
+}

--- a/nis/src/main/java/org/nem/nis/controller/viewmodels/ExpiredMosaicViewModel.java
+++ b/nis/src/main/java/org/nem/nis/controller/viewmodels/ExpiredMosaicViewModel.java
@@ -1,0 +1,54 @@
+package org.nem.nis.controller.viewmodels;
+
+import org.nem.core.model.*;
+import org.nem.core.model.mosaic.*;
+import org.nem.core.model.primitive.*;
+import org.nem.core.serialization.*;
+import org.nem.nis.state.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * View model composed of information about an expired mosaic, including all balances at time of expiry.
+ */
+public class ExpiredMosaicViewModel implements SerializableEntity {
+	private final MosaicId mosaicId;
+	private final List<AddressBalancePair> balances;
+
+	/**
+	 * Creates a new expired mosaic view model.
+	 *
+	 * @param mosaicId Expired mosaic id.
+	 * @param mosaicBalances Balances at time of expiration.
+	 */
+	public ExpiredMosaicViewModel(final MosaicId mosaicId, final ReadOnlyMosaicBalances mosaicBalances) {
+		this.mosaicId = mosaicId;
+		this.balances = mosaicBalances.getOwners()
+			.stream()
+			.map(address -> new AddressBalancePair(address, mosaicBalances.getBalance(address)))
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public void serialize(final Serializer serializer) {
+		serializer.writeObject("mosaicId", this.mosaicId);
+		serializer.writeObjectArray("balances", this.balances);
+	}
+
+	private static class AddressBalancePair implements SerializableEntity {
+		private final Address address;
+		private final Quantity quantity;
+
+		public AddressBalancePair(final Address address, final Quantity quantity) {
+			this.address = address;
+			this.quantity = quantity;
+		}
+
+		@Override
+		public void serialize(final Serializer serializer) {
+			Address.writeTo(serializer, "address", this.address);
+			Quantity.writeTo(serializer, "quantity", this.quantity);
+		}
+	}
+}

--- a/nis/src/main/java/org/nem/nis/secret/BlockTransactionObserverFactory.java
+++ b/nis/src/main/java/org/nem/nis/secret/BlockTransactionObserverFactory.java
@@ -87,7 +87,9 @@ public class BlockTransactionObserverFactory {
 		// depends on MosaicDefinitionCreationObserver and MosaicTransferObserver
 		builder.add(new AccountInfoMosaicIdsObserver(nisCache.getNamespaceCache(), nisCache.getAccountStateCache()));
 		builder.add(
-				new ExpiredNamespacesObserver(nisCache.getNamespaceCache(), nisCache.getAccountStateCache(), this.estimatedBlocksPerYear));
+				new ExpiredNamespacesObserver(
+						nisCache.getNamespaceCache(), nisCache.getAccountStateCache(), nisCache.getExpiredMosaicCache(),
+						this.estimatedBlocksPerYear, !options.contains(ObserverOption.NoExpiredMosaicTracking)));
 
 		// pruners
 		builder.add(new AccountStateCachePruningObserver(nisCache.getAccountStateCache(),

--- a/nis/src/main/java/org/nem/nis/secret/ObserverOption.java
+++ b/nis/src/main/java/org/nem/nis/secret/ObserverOption.java
@@ -23,5 +23,10 @@ public enum ObserverOption {
 	/**
 	 * No observation of outlinks.
 	 */
-	NoOutlinkObserver
+	NoOutlinkObserver,
+
+	/**
+	 * No expired mosaic tracking.
+	 */
+	NoExpiredMosaicTracking
 }

--- a/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
+++ b/nis/src/main/java/org/nem/specific/deploy/appconfig/NisAppConfig.java
@@ -218,13 +218,13 @@ public class NisAppConfig {
 	}
 
 	@Bean
-	public SynchronizedHashCache transactionHashCache() {
-		return new SynchronizedHashCache(new DefaultHashCache(50000, this.nisConfiguration().getTransactionHashRetentionTime()));
+	public SynchronizedPoxFacade poxFacade() {
+		return new SynchronizedPoxFacade(new DefaultPoxFacade(this.importanceCalculator()));
 	}
 
 	@Bean
-	public SynchronizedPoxFacade poxFacade() {
-		return new SynchronizedPoxFacade(new DefaultPoxFacade(this.importanceCalculator()));
+	public SynchronizedHashCache transactionHashCache() {
+		return new SynchronizedHashCache(new DefaultHashCache(50000, this.nisConfiguration().getTransactionHashRetentionTime()));
 	}
 
 	@Bean
@@ -236,9 +236,14 @@ public class NisAppConfig {
 	}
 
 	@Bean
+	public SynchronizedExpiredMosaicCache expiredMosaicCache() {
+		return new SynchronizedExpiredMosaicCache(new DefaultExpiredMosaicCache());
+	}
+
+	@Bean
 	public ReadOnlyNisCache nisCache() {
 		return new DefaultNisCache(this.accountCache(), this.accountStateCache(), this.poxFacade(), this.transactionHashCache(),
-				this.namespaceCache());
+				this.namespaceCache(), this.expiredMosaicCache());
 	}
 
 	@Bean

--- a/nis/src/test/java/org/nem/nis/cache/DefaultExpiredMosaicCacheTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/DefaultExpiredMosaicCacheTest.java
@@ -1,0 +1,8 @@
+package org.nem.nis.cache;
+
+public class DefaultExpiredMosaicCacheTest extends ExpiredMosaicCacheTest<DefaultExpiredMosaicCache> {
+	@Override
+	protected DefaultExpiredMosaicCache createImmutableCache() {
+		return new DefaultExpiredMosaicCache();
+	}
+}

--- a/nis/src/test/java/org/nem/nis/cache/DefaultNisCacheTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/DefaultNisCacheTest.java
@@ -18,10 +18,11 @@ public class DefaultNisCacheTest {
 		final SynchronizedPoxFacade poxFacade = Mockito.mock(SynchronizedPoxFacade.class);
 		final SynchronizedHashCache transactionsHashCache = Mockito.mock(SynchronizedHashCache.class);
 		final SynchronizedNamespaceCache namespaceCache = Mockito.mock(SynchronizedNamespaceCache.class);
+		final SynchronizedExpiredMosaicCache expiredMosaicCache = Mockito.mock(SynchronizedExpiredMosaicCache.class);
 
 		// Act:
 		final ReadOnlyNisCache cache = new DefaultNisCache(accountCache, accountStateCache, poxFacade, transactionsHashCache,
-				namespaceCache);
+				namespaceCache, expiredMosaicCache);
 
 		// Assert:
 		MatcherAssert.assertThat(cache.getAccountCache(), IsSame.sameInstance(accountCache));
@@ -29,6 +30,7 @@ public class DefaultNisCacheTest {
 		MatcherAssert.assertThat(cache.getPoxFacade(), IsSame.sameInstance(poxFacade));
 		MatcherAssert.assertThat(cache.getTransactionHashCache(), IsSame.sameInstance(transactionsHashCache));
 		MatcherAssert.assertThat(cache.getNamespaceCache(), IsSame.sameInstance(namespaceCache));
+		MatcherAssert.assertThat(cache.getExpiredMosaicCache(), IsSame.sameInstance(expiredMosaicCache));
 	}
 
 	@Test
@@ -61,18 +63,21 @@ public class DefaultNisCacheTest {
 			Mockito.verify(context.accountStateCache, Mockito.only()).copy();
 			Mockito.verify(context.transactionsHashCache, Mockito.only()).copy();
 			Mockito.verify(context.namespaceCache, Mockito.only()).copy();
+			Mockito.verify(context.expiredMosaicCache, Mockito.only()).copy();
 		} else {
 			Mockito.verify(context.accountCache, Mockito.only()).deepCopy();
 			Mockito.verify(context.accountStateCache, Mockito.only()).deepCopy();
 			Mockito.verify(context.transactionsHashCache, Mockito.only()).deepCopy();
 			Mockito.verify(context.namespaceCache, Mockito.only()).deepCopy();
+			Mockito.verify(context.expiredMosaicCache, Mockito.only()).deepCopy();
 		}
 
 		MatcherAssert.assertThat(copy.getPoxFacade(), IsSame.sameInstance(context2.poxFacade));
 		MatcherAssert.assertThat(copy.getAccountCache(), IsSame.sameInstance(context2.accountCache));
 		MatcherAssert.assertThat(copy.getAccountStateCache(), IsSame.sameInstance(context2.accountStateCache));
-		MatcherAssert.assertThat(copy.getNamespaceCache(), IsSame.sameInstance(context2.namespaceCache));
 		MatcherAssert.assertThat(copy.getTransactionHashCache(), IsSame.sameInstance(context2.transactionsHashCache));
+		MatcherAssert.assertThat(copy.getNamespaceCache(), IsSame.sameInstance(context2.namespaceCache));
+		MatcherAssert.assertThat(copy.getExpiredMosaicCache(), IsSame.sameInstance(context2.expiredMosaicCache));
 	}
 
 	@Test
@@ -91,6 +96,7 @@ public class DefaultNisCacheTest {
 		Mockito.verify(context2.accountStateCache, Mockito.only()).commit();
 		Mockito.verify(context2.transactionsHashCache, Mockito.only()).commit();
 		Mockito.verify(context2.namespaceCache, Mockito.only()).commit();
+		Mockito.verify(context2.expiredMosaicCache, Mockito.only()).commit();
 	}
 
 	@Test
@@ -115,6 +121,8 @@ public class DefaultNisCacheTest {
 		Mockito.when(original.transactionsHashCache.deepCopy()).thenReturn(copy.transactionsHashCache);
 		Mockito.when(original.namespaceCache.copy()).thenReturn(copy.namespaceCache);
 		Mockito.when(original.namespaceCache.deepCopy()).thenReturn(copy.namespaceCache);
+		Mockito.when(original.expiredMosaicCache.copy()).thenReturn(copy.expiredMosaicCache);
+		Mockito.when(original.expiredMosaicCache.deepCopy()).thenReturn(copy.expiredMosaicCache);
 	}
 
 	private static class TestContext {
@@ -123,7 +131,8 @@ public class DefaultNisCacheTest {
 		private final SynchronizedPoxFacade poxFacade = Mockito.mock(SynchronizedPoxFacade.class);
 		private final SynchronizedHashCache transactionsHashCache = Mockito.mock(SynchronizedHashCache.class);
 		private final SynchronizedNamespaceCache namespaceCache = Mockito.mock(SynchronizedNamespaceCache.class);
+		private final SynchronizedExpiredMosaicCache expiredMosaicCache = Mockito.mock(SynchronizedExpiredMosaicCache.class);
 		private final DefaultNisCache cache = new DefaultNisCache(this.accountCache, this.accountStateCache, this.poxFacade,
-				this.transactionsHashCache, this.namespaceCache);
+				this.transactionsHashCache, this.namespaceCache, this.expiredMosaicCache);
 	}
 }

--- a/nis/src/test/java/org/nem/nis/cache/ExpiredMosaicCacheTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/ExpiredMosaicCacheTest.java
@@ -1,0 +1,321 @@
+package org.nem.nis.cache;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.*;
+import org.junit.*;
+import org.nem.core.model.*;
+import org.nem.core.model.mosaic.MosaicId;
+import org.nem.core.model.namespace.*;
+import org.nem.core.model.primitive.*;
+import org.nem.core.test.*;
+import org.nem.nis.ForkConfiguration;
+import org.nem.nis.NemNamespaceEntry;
+import org.nem.nis.state.*;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.*;
+
+public abstract class ExpiredMosaicCacheTest<T extends ExpiredMosaicCache & DeepCopyableCache<T> & CommittableCache> {
+	/**
+	 * Creates a cache.
+	 *
+	 * @return The cache.
+	 */
+	protected T createCache() {
+		return this.createImmutableCache().copy();
+	}
+
+	/**
+	 * Creates a cache that has auto-caching disabled.
+	 *
+	 * @return The cache.
+	 */
+	protected abstract T createImmutableCache();
+
+	// region test utils
+
+	private MosaicBalances createMosaicBalancesWithSingleBalance(final Address address, final long balance) {
+		final MosaicBalances balances = new MosaicBalances();
+		balances.incrementBalance(address, new Quantity(balance));
+		return balances;
+	}
+
+	private void addFourExpirations(ExpiredMosaicCache cache) {
+		final MosaicBalances balances1 = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 10000);
+		cache.addExpiration(new BlockHeight(122), Utils.createMosaicId(111), balances1);
+
+		final MosaicBalances balances2 = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 20000);
+		cache.addExpiration(new BlockHeight(123), Utils.createMosaicId(222), balances2);
+
+		final MosaicBalances balances3 = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 30000);
+		cache.addExpiration(new BlockHeight(123), Utils.createMosaicId(333), balances3);
+
+		final MosaicBalances balances4 = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 40000);
+		cache.addExpiration(new BlockHeight(124), Utils.createMosaicId(444), balances4);
+	}
+
+	// endregion
+
+	// region constructor
+
+	@Test
+	public void cacheInitiallyIsEmpty() {
+		// Act:
+		final ExpiredMosaicCache cache = this.createCache();
+
+		// Assert:
+		MatcherAssert.assertThat(cache.size(), IsEqual.equalTo(0));
+		MatcherAssert.assertThat(cache.deepSize(), IsEqual.equalTo(0));
+	}
+
+	// endregion
+
+	// region findExpirationsAtHeight
+
+	@Test
+	public void findExpirationsAtHeightReturnsEmptyCollectionWhenNoExpirationsAtHeight() {
+		// Arrange:
+		final ExpiredMosaicCache cache = this.createCache();
+
+		final MosaicBalances balances = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 10000);
+		cache.addExpiration(new BlockHeight(123), Utils.createMosaicId(111), balances);
+
+		// Act:
+		Collection<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> expirations = cache.findExpirationsAtHeight(new BlockHeight(124));
+
+		// Assert:
+		MatcherAssert.assertThat(expirations.size(), IsEqual.equalTo(0));
+	}
+
+	@Test
+	public void findExpirationsAtHeightReturnsExpirationsWhenPresentAtHeight() {
+		// Arrange:
+		final ExpiredMosaicCache cache = this.createCache();
+
+		final MosaicBalances balances1 = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 10000);
+		cache.addExpiration(new BlockHeight(122), Utils.createMosaicId(111), balances1);
+
+		final MosaicBalances balances2 = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 20000);
+		cache.addExpiration(new BlockHeight(123), Utils.createMosaicId(222), balances2);
+
+		final MosaicBalances balances3 = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 30000);
+		cache.addExpiration(new BlockHeight(123), Utils.createMosaicId(333), balances3);
+
+		final MosaicBalances balances4 = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 40000);
+		cache.addExpiration(new BlockHeight(124), Utils.createMosaicId(444), balances4);
+
+		// Act: expirations are unsorted, so sort by mosaic name
+		Collection<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> expirations = cache.findExpirationsAtHeight(new BlockHeight(123));
+		List<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> expirationsList = expirations
+			.stream()
+			.sorted((e1, e2) -> e1.getKey().getName().compareTo(e2.getKey().getName()))
+			.collect(Collectors.toList());
+
+		// Assert:
+		MatcherAssert.assertThat(expirations.size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(expirationsList.get(0).getKey(), IsEqual.equalTo(Utils.createMosaicId(222)));
+		MatcherAssert.assertThat(expirationsList.get(0).getValue(), IsSame.sameInstance(balances2));
+		MatcherAssert.assertThat(expirationsList.get(1).getKey(), IsEqual.equalTo(Utils.createMosaicId(333)));
+		MatcherAssert.assertThat(expirationsList.get(1).getValue(), IsSame.sameInstance(balances3));
+	}
+
+	// endregion
+
+	// region addExpiration / removeAll
+
+	@Test
+	public void canAddSingleExpirationAtSingleHeight() {
+		// Arrange:
+		final ExpiredMosaicCache cache = this.createCache();
+
+		final MosaicBalances balances = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 10000);
+		cache.addExpiration(new BlockHeight(123), Utils.createMosaicId(111), balances);
+
+		// Act:
+		Collection<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> expirations = cache.findExpirationsAtHeight(new BlockHeight(123));
+
+		// Assert:
+		MatcherAssert.assertThat(cache.size(), IsEqual.equalTo(1));
+		MatcherAssert.assertThat(cache.deepSize(), IsEqual.equalTo(1));
+
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(1));
+	}
+
+	@Test
+	public void canAddMultipleExpirationsAtSingleHeight() {
+		// Arrange:
+		final ExpiredMosaicCache cache = this.createCache();
+
+		final MosaicBalances balances1 = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 20000);
+		cache.addExpiration(new BlockHeight(123), Utils.createMosaicId(222), balances1);
+
+		final MosaicBalances balances2 = this.createMosaicBalancesWithSingleBalance(Utils.generateRandomAddress(), 30000);
+		cache.addExpiration(new BlockHeight(123), Utils.createMosaicId(333), balances2);
+
+		// Assert:
+		MatcherAssert.assertThat(cache.size(), IsEqual.equalTo(1));
+		MatcherAssert.assertThat(cache.deepSize(), IsEqual.equalTo(2));
+
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(2));
+	}
+
+	@Test
+	public void canAddMultipleExpirationsAtMultipleHeights() {
+		// Arrange:
+		final ExpiredMosaicCache cache = this.createCache();
+
+		// Act:
+		this.addFourExpirations(cache);
+
+		// Assert:
+		MatcherAssert.assertThat(cache.size(), IsEqual.equalTo(3));
+		MatcherAssert.assertThat(cache.deepSize(), IsEqual.equalTo(4));
+
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(122)).size(), IsEqual.equalTo(1));
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(124)).size(), IsEqual.equalTo(1));
+	}
+
+	@Test
+	public void canRemoveAllExpirationsAtHeight() {
+		// Arrange:
+		final ExpiredMosaicCache cache = this.createCache();
+
+		this.addFourExpirations(cache);
+
+		// Act:
+		cache.removeAll(new BlockHeight(123));
+
+		// Assert:
+		MatcherAssert.assertThat(cache.size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(cache.deepSize(), IsEqual.equalTo(2));
+
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(122)).size(), IsEqual.equalTo(1));
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(0));
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(124)).size(), IsEqual.equalTo(1));
+	}
+
+	@Test
+	public void removeAllAtHeightWithoutExpirationsDoesNotChangeState() {
+		// Arrange:
+		final ExpiredMosaicCache cache = this.createCache();
+
+		this.addFourExpirations(cache);
+
+		// Act:
+		cache.removeAll(new BlockHeight(121));
+		cache.removeAll(new BlockHeight(125));
+
+		// Assert: no state changes
+		MatcherAssert.assertThat(cache.size(), IsEqual.equalTo(3));
+		MatcherAssert.assertThat(cache.deepSize(), IsEqual.equalTo(4));
+
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(122)).size(), IsEqual.equalTo(1));
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(124)).size(), IsEqual.equalTo(1));
+	}
+
+	// endregion
+
+	// region shallowCopyTo / copy / deepCopy
+
+	@Test
+	public void shallowCopyToCopiesAllEntries() {
+		// Assert:
+		this.assertBasicCopy(cache -> {
+			final T copy = this.createCache();
+			cache.shallowCopyTo(copy);
+			return copy;
+		});
+	}
+
+	@Test
+	public void shallowCopyRemoveAllIsUnlinked() {
+		// Arrange:
+		final T cache = this.createCacheForCopyTests();
+
+		// Act:
+		final T copy = this.createCache();
+		cache.shallowCopyTo(copy);
+
+		// Act: remove expirations
+		copy.removeAll(new BlockHeight(123));
+
+		// Assert: the expirations should be removed from only the copy but not the original
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(copy.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(0));
+	}
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void copyCopiesAllEntries() {
+		this.assertBasicCopy(CopyableCache::copy);
+	}
+
+	@Test
+	public void copyRemoveAllIsUnlinked() {
+		// Arrange:
+		final T cache = this.createCacheForCopyTests();
+
+		// Act:
+		final T copy = cache.copy();
+
+		// Act: remove expirations
+		copy.removeAll(new BlockHeight(123));
+
+		// Assert: the expirations should be removed from only the copy but not the original
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(copy.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(0));
+	}
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void deepCopyCopiesAllEntries() {
+		this.assertBasicCopy(DeepCopyableCache::deepCopy);
+	}
+
+	@Test
+	public void deepCopyRemoveAllIsUnlinked() {
+		// Arrange:
+		final T cache = this.createCacheForCopyTests();
+
+		// Act: remove expirations
+		final T copy = cache.deepCopy();
+		final T copyMutable = copy.copy();
+		copyMutable.removeAll(new BlockHeight(123));
+		copyMutable.commit();
+
+		// Assert: the expirations should be removed from only the copy but not the original
+		MatcherAssert.assertThat(cache.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(copy.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(0));
+	}
+
+	private T createCacheForCopyTests() {
+		final T cache = this.createImmutableCache();
+		final T copy = cache.copy();
+
+		this.addFourExpirations(copy);
+
+		copy.commit();
+		return cache;
+	}
+
+	private void assertBasicCopy(final Function<T, T> copyCache) {
+		// Arrange:
+		final T cache = this.createCacheForCopyTests();
+
+		// Act:
+		final T copy = copyCache.apply(cache);
+
+		// Assert: initial copy
+		MatcherAssert.assertThat(copy.size(), IsEqual.equalTo(3));
+		MatcherAssert.assertThat(copy.deepSize(), IsEqual.equalTo(4));
+
+		MatcherAssert.assertThat(copy.findExpirationsAtHeight(new BlockHeight(122)).size(), IsEqual.equalTo(1));
+		MatcherAssert.assertThat(copy.findExpirationsAtHeight(new BlockHeight(123)).size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(copy.findExpirationsAtHeight(new BlockHeight(124)).size(), IsEqual.equalTo(1));
+	}
+
+	// endregion
+}

--- a/nis/src/test/java/org/nem/nis/cache/SynchronizedExpiredMosaicCacheTest.java
+++ b/nis/src/test/java/org/nem/nis/cache/SynchronizedExpiredMosaicCacheTest.java
@@ -1,0 +1,8 @@
+package org.nem.nis.cache;
+
+public class SynchronizedExpiredMosaicCacheTest extends ExpiredMosaicCacheTest<SynchronizedExpiredMosaicCache> {
+	@Override
+	protected SynchronizedExpiredMosaicCache createImmutableCache() {
+		return new SynchronizedExpiredMosaicCache(new DefaultExpiredMosaicCache());
+	}
+}

--- a/nis/src/test/java/org/nem/nis/chain/integration/BlockChainHarvesterTest.java
+++ b/nis/src/test/java/org/nem/nis/chain/integration/BlockChainHarvesterTest.java
@@ -270,7 +270,8 @@ public class BlockChainHarvesterTest {
 		final DefaultNisCache nisCache = new DefaultNisCache(new SynchronizedAccountCache(new DefaultAccountCache()), accountStateCache,
 				new SynchronizedPoxFacade(new DefaultPoxFacade(NisUtils.createImportanceCalculator())),
 				new SynchronizedHashCache(new DefaultHashCache()),
-				new SynchronizedNamespaceCache(new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight())));
+				new SynchronizedNamespaceCache(new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight())),
+				new SynchronizedExpiredMosaicCache(new DefaultExpiredMosaicCache()));
 		final RealBlockChainTestContext context = new RealBlockChainTestContext(nisCache);
 
 		// Setup remote harvesting
@@ -307,7 +308,8 @@ public class BlockChainHarvesterTest {
 		final DefaultNisCache nisCache = new DefaultNisCache(new SynchronizedAccountCache(new DefaultAccountCache()), accountStateCache,
 				new SynchronizedPoxFacade(new DefaultPoxFacade(NisUtils.createImportanceCalculator())),
 				new SynchronizedHashCache(new DefaultHashCache()),
-				new SynchronizedNamespaceCache(new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight())));
+				new SynchronizedNamespaceCache(new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight())),
+				new SynchronizedExpiredMosaicCache(new DefaultExpiredMosaicCache()));
 		final RealBlockChainTestContext context = new RealBlockChainTestContext(nisCache);
 
 		// Setup remote harvesting, such that

--- a/nis/src/test/java/org/nem/nis/controller/ExpiredMosaicControllerTest.java
+++ b/nis/src/test/java/org/nem/nis/controller/ExpiredMosaicControllerTest.java
@@ -1,0 +1,152 @@
+package org.nem.nis.controller;
+
+import net.minidev.json.*;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.*;
+import org.mockito.Mockito;
+import org.nem.core.model.Address;
+import org.nem.core.model.mosaic.*;
+import org.nem.core.model.namespace.NamespaceId;
+import org.nem.core.model.primitive.*;
+import org.nem.core.node.NodeFeature;
+import org.nem.core.serialization.*;
+import org.nem.core.test.*;
+import org.nem.specific.deploy.NisConfiguration;
+import org.nem.nis.cache.DefaultExpiredMosaicCache;
+import org.nem.nis.controller.requests.*;
+import org.nem.nis.controller.viewmodels.ExpiredMosaicViewModel;
+import org.nem.nis.state.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ExpiredMosaicControllerTest {
+	@Test
+	public void expiredMosaicsFailsWhenTrackExpiredMosaicsIsDisabled() {
+		// Arrange:
+		final TestContext context = new TestContext();
+		Mockito.when(context.nisConfiguration.isFeatureSupported(NodeFeature.TRACK_EXPIRED_MOSAICS)).thenReturn(false);
+
+		final BlockHeightBuilder builder = new BlockHeightBuilder();
+		builder.setHeight("123");
+
+		// Act + Assert:
+		ExceptionAssert.assertThrows(v -> context.controller.expiredMosaics(builder), UnsupportedOperationException.class);
+	}
+
+	@Test
+	public void expiredMosaicsSucceedsWhenNoExpirationsAtBlock() {
+		// Arrange:
+		final TestContext context = new TestContext();
+
+		final BlockHeightBuilder builder = new BlockHeightBuilder();
+		builder.setHeight("130");
+
+		// Act:
+		final SerializableList<ExpiredMosaicViewModel> expiredMosaics = context.controller.expiredMosaics(builder);
+
+		// Assert:
+		MatcherAssert.assertThat(expiredMosaics.size(), IsEqual.equalTo(0));
+	}
+
+	@Test
+	public void expiredMosaicsSucceedsWhenExpirationsAtBlock() {
+		// Arrange:
+		final Address address1 = Utils.generateRandomAddress();
+		final Address address2 = Utils.generateRandomAddress();
+		final TestContext context = new TestContext(address1, address2);
+
+		final BlockHeightBuilder builder = new BlockHeightBuilder();
+		builder.setHeight("123");
+
+		// Act:
+		final SerializableList<ExpiredMosaicViewModel> expiredMosaics = context.controller.expiredMosaics(builder);
+
+		// Assert:
+		MatcherAssert.assertThat(expiredMosaics.size(), IsEqual.equalTo(2));
+
+		// - there are no accessors on the view model, so serialize and inspect the json
+		final JSONObject jsonObject1 = JsonSerializer.serializeToJson(expiredMosaics.get(0));
+		final JSONObject jsonObject2 = JsonSerializer.serializeToJson(expiredMosaics.get(1));
+
+		final MosaicId mosaicId1 = deserializeMosaicId(jsonObject1);
+		final MosaicId mosaicId2 = deserializeMosaicId(jsonObject2);
+
+		MatcherAssert.assertThat(
+			Arrays.asList(mosaicId1, mosaicId2),
+			IsEquivalent.equivalentTo(Arrays.asList(Utils.createMosaicId(222), Utils.createMosaicId(333))));
+
+		// - ensure balanceMap1 => mosaicId 222 and balanceMap2 => mosaicId 333
+		final Map<Address, Quantity> balanceMap1 = this.deserializeBalanceMap(mosaicId1.equals(Utils.createMosaicId(222)) ? jsonObject1 : jsonObject2);
+		final Map<Address, Quantity> balanceMap2 = this.deserializeBalanceMap(mosaicId1.equals(Utils.createMosaicId(222)) ? jsonObject2 : jsonObject1);
+
+		MatcherAssert.assertThat(balanceMap1.keySet(), IsEquivalent.equivalentTo(Arrays.asList(address1, address2)));
+		MatcherAssert.assertThat(balanceMap1.get(address1), IsEqual.equalTo(new Quantity(20000)));
+		MatcherAssert.assertThat(balanceMap1.get(address2), IsEqual.equalTo(new Quantity(9999)));
+
+		MatcherAssert.assertThat(balanceMap2.keySet(), IsEquivalent.equivalentTo(Collections.singletonList(address1)));
+		MatcherAssert.assertThat(balanceMap2.get(address1), IsEqual.equalTo(new Quantity(30000)));
+	}
+
+	private MosaicId deserializeMosaicId(final JSONObject jsonObject) {
+		return new MosaicId(
+			new NamespaceId((String) ((JSONObject) jsonObject.get("mosaicId")).get("namespaceId")),
+			(String) ((JSONObject) jsonObject.get("mosaicId")).get("name")
+		);
+	}
+
+	private Map<Address, Quantity> deserializeBalanceMap(final JSONObject jsonObject) {
+		JSONArray jsonBalances = (JSONArray) jsonObject.get("balances");
+		return jsonBalances.stream()
+				.map(obj -> (JSONObject) obj)
+				.collect(Collectors.toMap(
+					jsonBalance -> Address.fromEncoded((String) jsonBalance.get("address")),
+					jsonBalance -> new Quantity((Long) jsonBalance.get("quantity"))
+			));
+	}
+
+	private static class TestContext {
+		private final NisConfiguration nisConfiguration = Mockito.mock(NisConfiguration.class);
+		private final DefaultExpiredMosaicCache expiredMosaicCache;
+		private final ExpiredMosaicController controller;
+
+		public TestContext() {
+			this(Utils.generateRandomAddress(), Utils.generateRandomAddress());
+		}
+
+		public TestContext(final Address address1, final Address address2) {
+			this.expiredMosaicCache = this.createAndSeedCache(address1, address2);
+			this.controller = new ExpiredMosaicController(this.nisConfiguration, this.expiredMosaicCache);
+
+			Mockito.when(this.nisConfiguration.isFeatureSupported(NodeFeature.TRACK_EXPIRED_MOSAICS)).thenReturn(true);
+		}
+
+		private DefaultExpiredMosaicCache createAndSeedCache(final Address address1, final Address address2) {
+			final DefaultExpiredMosaicCache cache = new DefaultExpiredMosaicCache();
+			final DefaultExpiredMosaicCache copy = cache.copy();
+
+			final MosaicBalances balances1 = this.createMosaicBalancesWithSingleBalance(address1, 10000);
+			copy.addExpiration(new BlockHeight(122), Utils.createMosaicId(111), balances1);
+
+			final MosaicBalances balances2 = this.createMosaicBalancesWithSingleBalance(address1, 20000);
+			balances2.incrementBalance(address2, new Quantity(9999));
+			copy.addExpiration(new BlockHeight(123), Utils.createMosaicId(222), balances2);
+
+			final MosaicBalances balances3 = this.createMosaicBalancesWithSingleBalance(address1, 30000);
+			copy.addExpiration(new BlockHeight(123), Utils.createMosaicId(333), balances3);
+
+			final MosaicBalances balances4 = this.createMosaicBalancesWithSingleBalance(address1, 40000);
+			copy.addExpiration(new BlockHeight(124), Utils.createMosaicId(444), balances4);
+
+			copy.commit();
+			return cache;
+		}
+
+		private MosaicBalances createMosaicBalancesWithSingleBalance(final Address address, final long balance) {
+			final MosaicBalances balances = new MosaicBalances();
+			balances.incrementBalance(address, new Quantity(balance));
+			return balances;
+		}
+	}
+}

--- a/nis/src/test/java/org/nem/nis/controller/viewmodels/ExpiredMosaicViewModelTest.java
+++ b/nis/src/test/java/org/nem/nis/controller/viewmodels/ExpiredMosaicViewModelTest.java
@@ -1,0 +1,78 @@
+package org.nem.nis.controller.viewmodels;
+
+import net.minidev.json.*;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.*;
+import org.junit.*;
+import org.nem.core.model.*;
+import org.nem.core.model.mosaic.*;
+import org.nem.core.model.namespace.*;
+import org.nem.core.model.primitive.*;
+import org.nem.core.serialization.*;
+import org.nem.core.test.*;
+import org.nem.nis.state.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ExpiredMosaicViewModelTest {
+	@Test
+	public void canSerializeWithoutBalances() {
+		// Arrange:
+		final ExpiredMosaicViewModel viewModel = new ExpiredMosaicViewModel(
+			new MosaicId(new NamespaceId("alice"), "tokens"),
+			new MosaicBalances());
+
+		// Act:
+		final JSONObject jsonObject = JsonSerializer.serializeToJson(viewModel);
+
+		// Assert:
+		MatcherAssert.assertThat(jsonObject.size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(((JSONObject) jsonObject.get("mosaicId")).get("namespaceId"), IsEqual.equalTo("alice"));
+		MatcherAssert.assertThat(((JSONObject) jsonObject.get("mosaicId")).get("name"), IsEqual.equalTo("tokens"));
+		MatcherAssert.assertThat(((JSONArray) jsonObject.get("balances")).size(), IsEqual.equalTo(0));
+	}
+
+	@Test
+	public void canSerializeWithBalances() {
+		// Arrange:
+		final Address address1 = Utils.generateRandomAddress();
+		final Address address2 = Utils.generateRandomAddress();
+		final Address address3 = Utils.generateRandomAddress();
+
+		final MosaicBalances balances = new MosaicBalances();
+		balances.incrementBalance(address1, new Quantity(111));
+		balances.incrementBalance(address2, new Quantity(333));
+		balances.incrementBalance(address3, new Quantity(222));
+
+		final ExpiredMosaicViewModel viewModel = new ExpiredMosaicViewModel(new MosaicId(new NamespaceId("alice"), "tokens"), balances);
+
+		// Act:
+		final JSONObject jsonObject = JsonSerializer.serializeToJson(viewModel);
+
+		// Assert:
+		MatcherAssert.assertThat(jsonObject.size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(((JSONObject) jsonObject.get("mosaicId")).get("namespaceId"), IsEqual.equalTo("alice"));
+		MatcherAssert.assertThat(((JSONObject) jsonObject.get("mosaicId")).get("name"), IsEqual.equalTo("tokens"));
+
+		JSONArray jsonBalances = (JSONArray) jsonObject.get("balances");
+		MatcherAssert.assertThat(jsonBalances.size(), IsEqual.equalTo(3));
+
+		jsonBalances.forEach(obj -> {
+			MatcherAssert.assertThat(((JSONObject) obj).size(), IsEqual.equalTo(2));
+		});
+
+		// - balances array is unordered, so read it into a map for further inspection
+		final Map<Address, Quantity> balanceMap = jsonBalances.stream()
+				.map(obj -> (JSONObject) obj)
+				.collect(Collectors.toMap(
+					jsonBalance -> Address.fromEncoded((String) jsonBalance.get("address")),
+					jsonBalance -> new Quantity((Long) jsonBalance.get("quantity"))
+			));
+
+		MatcherAssert.assertThat(balanceMap.keySet(), IsEquivalent.equivalentTo(Arrays.asList(address1, address2, address3)));
+		MatcherAssert.assertThat(balanceMap.get(address1), IsEqual.equalTo(new Quantity(111)));
+		MatcherAssert.assertThat(balanceMap.get(address2), IsEqual.equalTo(new Quantity(333)));
+		MatcherAssert.assertThat(balanceMap.get(address3), IsEqual.equalTo(new Quantity(222)));
+	}
+}

--- a/nis/src/test/java/org/nem/nis/secret/ExpiredNamespacesObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/ExpiredNamespacesObserverTest.java
@@ -1,6 +1,7 @@
 package org.nem.nis.secret;
 
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.*;
 import org.junit.*;
 import org.mockito.Mockito;
 import org.nem.core.model.Address;
@@ -38,7 +39,9 @@ public class ExpiredNamespacesObserverTest {
 
 		// Sanity:
 		assertAccountOwnsMosaics(context.accountInfo1, Collections.singletonList(context.mosaicDefinition1.getId()));
-		assertAccountOwnsMosaics(context.accountInfo2, Arrays.asList(context.mosaicDefinition1.getId(), context.mosaicDefinition2.getId()));
+		assertAccountOwnsMosaics(
+			context.accountInfo2,
+			Arrays.asList(context.mosaicDefinition1.getId(), context.mosaicDefinition2.getId(), context.mosaicDefinition3.getId()));
 
 		// Act:
 		// namespace 2 will expire, namespace 1 not.
@@ -46,11 +49,46 @@ public class ExpiredNamespacesObserverTest {
 
 		// Assert:
 		// mosaic id 1 should still be with both accounts
-		// mosaic id 2 should have been removed from account 2
+		// mosaic id 2 and 3 should have been removed from account 2
 		Mockito.verify(context.accountStateCache, Mockito.never()).findStateByAddress(context.mosaicDefinition1.getCreator().getAddress());
-		Mockito.verify(context.accountStateCache, Mockito.only()).findStateByAddress(context.mosaicDefinition2.getCreator().getAddress());
+		Mockito.verify(context.accountStateCache, Mockito.times(2)).findStateByAddress(context.mosaicDefinition2.getCreator().getAddress());
 		assertAccountOwnsMosaics(context.accountInfo1, Collections.singletonList(context.mosaicDefinition1.getId()));
 		assertAccountOwnsMosaics(context.accountInfo2, Collections.singletonList(context.mosaicDefinition1.getId()));
+
+		// - no changes to expired mosaic cache because it's disabled
+		MatcherAssert.assertThat(context.expiredMosaicCache.size(), IsEqual.equalTo(0));
+	}
+
+	@Test
+	public void notifyExecuteAddsExpiredMosaicsToExpiredMosaicCache_SingleNamespaceExpiry() {
+		// Arrange:
+		final TestContext context = new TestContext(new BlockHeight(321), new BlockHeight(123));
+		context.addMosaicsToAccounts();
+
+		final ExpiredNamespacesObserver observer = context.createObserver(true);
+
+		// Act: namespace 2 will expire, namespace 1 not.
+		notify(observer, NotificationTrigger.Execute);
+
+		// Assert: changes to expired mosaic cache because it's enabled
+		MatcherAssert.assertThat(context.expiredMosaicCache.size(), IsEqual.equalTo(1));
+		MatcherAssert.assertThat(context.expiredMosaicCache.deepSize(), IsEqual.equalTo(2));
+	}
+
+	@Test
+	public void notifyExecuteAddsExpiredMosaicsToExpiredMosaicCache_MultipleNamespaceExpiry() {
+		// Arrange: configure both namespaces to expire at same height
+		final TestContext context = new TestContext(new BlockHeight(123), new BlockHeight(123));
+		context.addMosaicsToAccounts();
+
+		final ExpiredNamespacesObserver observer = context.createObserver(true);
+
+		// Act: namespaces 1 and 2 will expire
+		notify(observer, NotificationTrigger.Execute);
+
+		// Assert: changes to expired mosaic cache because it's enabled
+		MatcherAssert.assertThat(context.expiredMosaicCache.size(), IsEqual.equalTo(1));
+		MatcherAssert.assertThat(context.expiredMosaicCache.deepSize(), IsEqual.equalTo(3));
 	}
 
 	// endregion
@@ -75,11 +113,38 @@ public class ExpiredNamespacesObserverTest {
 		// Act: namespace 2 will be brought back to life, namespace 1 not.
 		notify(context, NotificationTrigger.Undo);
 
-		// Assert: mosaic id 2 should have been added to account 2, account 1 should be unchanged
+		// Assert: mosaic ids 2 and 3 should have been added to account 2, account 1 should be unchanged
 		Mockito.verify(context.accountStateCache, Mockito.never()).findStateByAddress(context.mosaicDefinition1.getCreator().getAddress());
-		Mockito.verify(context.accountStateCache, Mockito.only()).findStateByAddress(context.mosaicDefinition2.getCreator().getAddress());
+		Mockito.verify(context.accountStateCache, Mockito.times(2)).findStateByAddress(context.mosaicDefinition2.getCreator().getAddress());
 		assertAccountOwnsMosaics(context.accountInfo1, Collections.emptyList());
-		assertAccountOwnsMosaics(context.accountInfo2, Collections.singletonList(context.mosaicDefinition2.getId()));
+		assertAccountOwnsMosaics(context.accountInfo2, Arrays.asList(context.mosaicDefinition2.getId(), context.mosaicDefinition3.getId()));
+
+		// - no changes to expired mosaic cache because it's disabled
+		MatcherAssert.assertThat(context.expiredMosaicCache.size(), IsEqual.equalTo(0));
+	}
+
+	@Test
+	public void notifyUndoRemovesExpiredMosaicsFromExpiredMosaicCache() {
+		// Arrange:
+		final TestContext context = new TestContext(new BlockHeight(123), new BlockHeight(123));
+		context.addMosaicsToAccounts();
+		context.addExpiredMosaics(new BlockHeight(NOTIFY_BLOCK_HEIGHT - 1)); // should not be dropped
+		context.addExpiredMosaics(new BlockHeight(NOTIFY_BLOCK_HEIGHT)); // should be dropped
+		context.addExpiredMosaics(new BlockHeight(NOTIFY_BLOCK_HEIGHT + 1)); // should not be dropped
+
+		// Sanity:
+		MatcherAssert.assertThat(context.expiredMosaicCache.size(), IsEqual.equalTo(3));
+		MatcherAssert.assertThat(context.expiredMosaicCache.deepSize(), IsEqual.equalTo(9));
+
+		final ExpiredNamespacesObserver observer = context.createObserver(true);
+
+		// Act: all expirations at height will be dropped
+		notify(observer, NotificationTrigger.Undo);
+
+		// Assert: changes to expired mosaic cache because it's enabled
+		//         [notice specific mosaicId(s) don't matter, only those expirations at matching height are removed]
+		MatcherAssert.assertThat(context.expiredMosaicCache.size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(context.expiredMosaicCache.deepSize(), IsEqual.equalTo(6));
 	}
 
 	// endregion
@@ -95,7 +160,11 @@ public class ExpiredNamespacesObserverTest {
 
 		// Sanity:
 		assertAccountOwnsMosaics(context.accountInfo1, Collections.singletonList(context.mosaicDefinition1.getId()));
-		assertAccountOwnsMosaics(context.accountInfo2, Arrays.asList(context.mosaicDefinition1.getId(), context.mosaicDefinition2.getId()));
+		assertAccountOwnsMosaics(context.accountInfo2, Arrays.asList(
+			context.mosaicDefinition1.getId(),
+			context.mosaicDefinition2.getId(),
+			context.mosaicDefinition3.getId()
+		));
 
 		// Act:
 		notify(context, notificationTrigger);
@@ -105,23 +174,32 @@ public class ExpiredNamespacesObserverTest {
 	}
 
 	private static void notify(final TestContext context, final NotificationTrigger notificationTrigger) {
-		// Arrange:
-		final ExpiredNamespacesObserver observer = context.createObserver();
+		ExpiredNamespacesObserverTest.notify(context.createObserver(), notificationTrigger);
+	}
 
-		// Act:
+	private static void notify(final ExpiredNamespacesObserver observer, final NotificationTrigger notificationTrigger) {
 		observer.notify(new BalanceAdjustmentNotification(NotificationType.BlockHarvest, Utils.generateRandomAccount(), Amount.ZERO),
 				NisUtils.createBlockNotificationContext(new BlockHeight(NOTIFY_BLOCK_HEIGHT), notificationTrigger));
 	}
 
 	private static class TestContext {
+		// 2 and 3 have same namespace
 		private final MosaicDefinition mosaicDefinition1 = Utils.createMosaicDefinition(1, createMosaicProperties());
 		private final MosaicDefinition mosaicDefinition2 = Utils.createMosaicDefinition(2, createMosaicProperties());
+		private final MosaicDefinition mosaicDefinition3 = Utils.createMosaicDefinition(
+			mosaicDefinition2.getCreator(),
+			new MosaicId(mosaicDefinition2.getId().getNamespaceId(), "name3"),
+			createMosaicProperties()
+		);
+
 		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight())
 				.copy();
 		private final DefaultAccountStateCache accountStateCache = Mockito.mock(DefaultAccountStateCache.class);
 		private final AccountInfo accountInfo1;
 		private final AccountInfo accountInfo2;
+
+		private final DefaultExpiredMosaicCache expiredMosaicCache = new DefaultExpiredMosaicCache().copy();
 
 		private TestContext(final BlockHeight height1, final BlockHeight height2) {
 			// mosaic 1
@@ -130,11 +208,12 @@ public class ExpiredNamespacesObserverTest {
 			final Mosaics mosaics1 = this.namespaceCache.get(namespaceId1).getMosaics();
 			mosaics1.add(this.mosaicDefinition1);
 
-			// mosaic 2
+			// mosaic 2 + 3
 			final NamespaceId namespaceId2 = this.mosaicDefinition2.getId().getNamespaceId();
 			this.namespaceCache.add(new Namespace(namespaceId2, this.mosaicDefinition2.getCreator(), height2));
 			final Mosaics mosaics2 = this.namespaceCache.get(namespaceId2).getMosaics();
 			mosaics2.add(this.mosaicDefinition2);
+			mosaics2.add(this.mosaicDefinition3);
 
 			// account info 1
 			final Address address1 = mosaicDefinition1.getCreator().getAddress();
@@ -152,7 +231,14 @@ public class ExpiredNamespacesObserverTest {
 		}
 
 		private ExpiredNamespacesObserver createObserver() {
-			return new ExpiredNamespacesObserver(this.namespaceCache, this.accountStateCache, ESTIMATED_BLOCKS_PER_YEAR);
+			return this.createObserver(false);
+		}
+
+		private ExpiredNamespacesObserver createObserver(final boolean shouldTrackExpiredMosaics) {
+			return new ExpiredNamespacesObserver(
+				this.namespaceCache, this.accountStateCache, this.expiredMosaicCache, ESTIMATED_BLOCKS_PER_YEAR,
+				shouldTrackExpiredMosaics
+			);
 		}
 
 		private void addMosaicsToNamespaceMosaicsBalances() {
@@ -163,14 +249,26 @@ public class ExpiredNamespacesObserverTest {
 			final MosaicId id2 = this.mosaicDefinition2.getId();
 			this.namespaceCache.get(id2.getNamespaceId()).getMosaics().get(id2).getBalances()
 					.incrementBalance(mosaicDefinition2.getCreator().getAddress(), Quantity.fromValue(1));
+
+			final MosaicId id3 = this.mosaicDefinition3.getId();
+			this.namespaceCache.get(id3.getNamespaceId()).getMosaics().get(id3).getBalances()
+					.incrementBalance(mosaicDefinition3.getCreator().getAddress(), Quantity.fromValue(1));
 		}
 
 		// account 1: owns only mosaic 1
-		// account 2: owns mosaic 1 and mosaic 2
+		// account 2: owns mosaic 1 and mosaic 2 and mosaic 3
 		private void addMosaicsToAccounts() {
 			this.accountInfo1.addMosaicId(mosaicDefinition1.getId());
+
 			this.accountInfo2.addMosaicId(mosaicDefinition1.getId());
 			this.accountInfo2.addMosaicId(mosaicDefinition2.getId());
+			this.accountInfo2.addMosaicId(mosaicDefinition3.getId());
+		}
+
+		private void addExpiredMosaics(final BlockHeight height) {
+			this.expiredMosaicCache.addExpiration(height, this.mosaicDefinition1.getId(), new MosaicBalances());
+			this.expiredMosaicCache.addExpiration(height, this.mosaicDefinition2.getId(), new MosaicBalances());
+			this.expiredMosaicCache.addExpiration(height, this.mosaicDefinition3.getId(), new MosaicBalances());
 		}
 	}
 }

--- a/nis/src/test/java/org/nem/nis/test/NisCacheFactory.java
+++ b/nis/src/test/java/org/nem/nis/test/NisCacheFactory.java
@@ -29,7 +29,8 @@ public class NisCacheFactory {
 		return new DefaultNisCache(new SynchronizedAccountCache(new DefaultAccountCache()),
 				new SynchronizedAccountStateCache(new DefaultAccountStateCache()), new SynchronizedPoxFacade(poxFacade),
 				new SynchronizedHashCache(new DefaultHashCache()),
-				new SynchronizedNamespaceCache(new DefaultNamespaceCache(mosaicRedefinitionForkHeight)));
+				new SynchronizedNamespaceCache(new DefaultNamespaceCache(mosaicRedefinitionForkHeight)),
+				new SynchronizedExpiredMosaicCache(new DefaultExpiredMosaicCache()));
 	}
 
 	// endregion
@@ -44,7 +45,7 @@ public class NisCacheFactory {
 	 * @return The NIS cache.
 	 */
 	public static NisCache create(final AccountCache accountCache, final AccountStateCache accountStateCache) {
-		return create(accountCache, accountStateCache, null, null, null);
+		return create(accountCache, accountStateCache, null, null, null, null);
 	}
 
 	/**
@@ -54,7 +55,7 @@ public class NisCacheFactory {
 	 * @return The NIS cache.
 	 */
 	public static NisCache create(final AccountStateCache accountStateCache) {
-		return create(null, accountStateCache, null, null, null);
+		return create(null, accountStateCache, null, null, null, null);
 	}
 
 	/**
@@ -65,11 +66,12 @@ public class NisCacheFactory {
 	 * @return The NIS cache.
 	 */
 	public static NisCache create(final AccountStateCache accountStateCache, final DefaultPoxFacade poxFacade) {
-		return create(null, accountStateCache, poxFacade, null, null);
+		return create(null, accountStateCache, poxFacade, null, null, null);
 	}
 
 	private static NisCache create(final AccountCache accountCache, final AccountStateCache accountStateCache,
-			final DefaultPoxFacade poxFacade, final DefaultHashCache hashCache, final DefaultNamespaceCache namespaceCache) {
+			final DefaultPoxFacade poxFacade, final DefaultHashCache hashCache, final DefaultNamespaceCache namespaceCache,
+			final DefaultExpiredMosaicCache expiredMosaicCache) {
 		return new NisCache() {
 			@Override
 			public AccountCache getAccountCache() {
@@ -97,6 +99,11 @@ public class NisCacheFactory {
 			}
 
 			@Override
+			public DefaultExpiredMosaicCache getExpiredMosaicCache() {
+				return null == expiredMosaicCache ? Mockito.mock(DefaultExpiredMosaicCache.class) : expiredMosaicCache;
+			}
+
+			@Override
 			public void commit() {
 			}
 
@@ -119,14 +126,15 @@ public class NisCacheFactory {
 	 * @return The NIS cache.
 	 */
 	public static ReadOnlyNisCache createReadOnly(final AccountCache accountCache, final ReadOnlyAccountStateCache accountStateCache) {
-		return createReadOnly(accountCache, accountStateCache, null, null, null);
+		return createReadOnly(accountCache, accountStateCache, null, null, null, null);
 	}
 
 	private static ReadOnlyNisCache createReadOnly(final AccountCache accountCache, final ReadOnlyAccountStateCache accountStateCache,
-			final DefaultHashCache hashCache, final ReadOnlyPoxFacade poxFacade, final ReadOnlyNamespaceCache namespaceCache) {
+			final DefaultHashCache hashCache, final ReadOnlyPoxFacade poxFacade, final ReadOnlyNamespaceCache namespaceCache,
+			final ReadOnlyExpiredMosaicCache expiredMosaicCache) {
 		return new ReadOnlyNisCache() {
 			@Override
-			public AccountCache getAccountCache() {
+			public ReadOnlyAccountCache getAccountCache() {
 				return null == accountCache ? Mockito.mock(AccountCache.class) : accountCache;
 			}
 
@@ -141,13 +149,18 @@ public class NisCacheFactory {
 			}
 
 			@Override
-			public DefaultHashCache getTransactionHashCache() {
-				return null == hashCache ? Mockito.mock(DefaultHashCache.class) : hashCache;
+			public ReadOnlyHashCache getTransactionHashCache() {
+				return null == hashCache ? Mockito.mock(HashCache.class) : hashCache;
 			}
 
 			@Override
 			public ReadOnlyNamespaceCache getNamespaceCache() {
 				return null == namespaceCache ? Mockito.mock(NamespaceCache.class) : namespaceCache;
+			}
+
+			@Override
+			public ReadOnlyExpiredMosaicCache getExpiredMosaicCache() {
+				return null == expiredMosaicCache ? Mockito.mock(ExpiredMosaicCache.class) : expiredMosaicCache;
 			}
 
 			@Override

--- a/nis/src/test/java/org/nem/specific/deploy/NisConfigurationTest.java
+++ b/nis/src/test/java/org/nem/specific/deploy/NisConfigurationTest.java
@@ -241,7 +241,7 @@ public class NisConfigurationTest {
 		final NisConfiguration config = new NisConfiguration(properties);
 
 		// Assert:
-		MatcherAssert.assertThat(config.isFeatureSupported(NodeFeature.PLACEHOLDER2), IsEqual.equalTo(false));
+		MatcherAssert.assertThat(config.isFeatureSupported(NodeFeature.TRACK_EXPIRED_MOSAICS), IsEqual.equalTo(false));
 	}
 
 	@Test

--- a/peer/src/test/java/org/nem/peer/ConfigTest.java
+++ b/peer/src/test/java/org/nem/peer/ConfigTest.java
@@ -186,7 +186,7 @@ public class ConfigTest {
 
 		final JSONObject peersConfig = ConfigFactory.createDefaultPeersConfig();
 		return new Config(localNode, peersConfig, "2.0.0", 4, new NodeFeature[]{
-				NodeFeature.HISTORICAL_ACCOUNT_DATA, NodeFeature.PLACEHOLDER2
+				NodeFeature.HISTORICAL_ACCOUNT_DATA, NodeFeature.TRACK_EXPIRED_MOSAICS
 		});
 	}
 

--- a/peer/src/test/java/org/nem/peer/test/ConfigFactory.java
+++ b/peer/src/test/java/org/nem/peer/test/ConfigFactory.java
@@ -78,7 +78,7 @@ public class ConfigFactory {
 	 */
 	public static Config createDefaultTestConfig() {
 		return new Config(createDefaultLocalNode(), createDefaultPeersConfig(), "2.0.0", 4, new NodeFeature[]{
-				NodeFeature.HISTORICAL_ACCOUNT_DATA, NodeFeature.PLACEHOLDER2
+				NodeFeature.HISTORICAL_ACCOUNT_DATA, NodeFeature.TRACK_EXPIRED_MOSAICS
 		});
 	}
 


### PR DESCRIPTION
    [nis]: NIS does not provide any information about expiring mosaics
    
     problem: rosetta reconcilation fails because it expects expired (zeroed) mosaics to be part of account
    solution: track expired mosaics in new ExpiredMosaicCache (historical node only)
              expose new (local) endpoint [/local/mosaics/expire] that returns all mosaics expired at a block

    [nis]: add new TRACK_EXPIRED_MOSAICS node feature
    
     problem: tracking expensive mosaics should not be limited to historical nodes
    solution: add new feature to independently enable this feature
