### PR TITLE
[nis]: add handling for restored mosaics when owner renews expired namespace

### DIFF
--- a/nis/src/main/java/org/nem/nis/cache/ExpiredMosaicCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/ExpiredMosaicCache.java
@@ -2,7 +2,7 @@ package org.nem.nis.cache;
 
 import org.nem.core.model.mosaic.MosaicId;
 import org.nem.core.model.primitive.BlockHeight;
-import org.nem.nis.state.ReadOnlyMosaicBalances;
+import org.nem.nis.state.*;
 
 /**
  * An expired mosaic cache containing information about mosaics that were zeroed upon expiration.
@@ -14,8 +14,9 @@ public interface ExpiredMosaicCache extends ReadOnlyExpiredMosaicCache {
 	 * @param height Height of expiration.
 	 * @param mosaicId Id of expiring mosaic.
 	 * @param balances Expiring mosaic balances.
+	 * @param expirationType Type of expiration.
 	 */
-	void addExpiration(final BlockHeight height, final MosaicId mosaicId, final ReadOnlyMosaicBalances balances);
+	void addExpiration(final BlockHeight height, final MosaicId mosaicId, final ReadOnlyMosaicBalances balances, final ExpiredMosaicType expirationType);
 
 	/**
 	 * Removes all expirations at the specified height.

--- a/nis/src/main/java/org/nem/nis/cache/ReadOnlyExpiredMosaicCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/ReadOnlyExpiredMosaicCache.java
@@ -2,7 +2,7 @@ package org.nem.nis.cache;
 
 import org.nem.core.model.mosaic.MosaicId;
 import org.nem.core.model.primitive.BlockHeight;
-import org.nem.nis.state.ReadOnlyMosaicBalances;
+import org.nem.nis.state.*;
 
 import java.util.*;
 
@@ -27,5 +27,5 @@ public interface ReadOnlyExpiredMosaicCache {
 	 * @param height Height of expiration.
 	 * @return All expiring mosaics at height.
 	 */
-	Collection<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> findExpirationsAtHeight(BlockHeight height);
+	Collection<ExpiredMosaicEntry> findExpirationsAtHeight(BlockHeight height);
 }

--- a/nis/src/main/java/org/nem/nis/cache/SynchronizedExpiredMosaicCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/SynchronizedExpiredMosaicCache.java
@@ -2,7 +2,7 @@ package org.nem.nis.cache;
 
 import org.nem.core.model.mosaic.*;
 import org.nem.core.model.primitive.*;
-import org.nem.nis.state.ReadOnlyMosaicBalances;
+import org.nem.nis.state.*;
 
 import java.util.*;
 
@@ -37,16 +37,16 @@ public class SynchronizedExpiredMosaicCache implements ExpiredMosaicCache, DeepC
 	}
 
 	@Override
-	public Collection<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> findExpirationsAtHeight(BlockHeight height) {
+	public Collection<ExpiredMosaicEntry> findExpirationsAtHeight(BlockHeight height) {
 		synchronized (this.lock) {
 			return this.cache.findExpirationsAtHeight(height);
 		}
 	}
 
 	@Override
-	public void addExpiration(final BlockHeight height, final MosaicId mosaicId, final ReadOnlyMosaicBalances balances) {
+	public void addExpiration(final BlockHeight height, final MosaicId mosaicId, final ReadOnlyMosaicBalances balances, final ExpiredMosaicType expirationType) {
 		synchronized (this.lock) {
-			this.cache.addExpiration(height, mosaicId, balances);
+			this.cache.addExpiration(height, mosaicId, balances, expirationType);
 		}
 	}
 

--- a/nis/src/main/java/org/nem/nis/controller/ExpiredMosaicController.java
+++ b/nis/src/main/java/org/nem/nis/controller/ExpiredMosaicController.java
@@ -9,8 +9,7 @@ import org.nem.nis.cache.*;
 import org.nem.nis.controller.annotations.*;
 import org.nem.nis.controller.requests.BlockHeightBuilder;
 import org.nem.nis.controller.viewmodels.ExpiredMosaicViewModel;
-
-import org.nem.nis.state.ReadOnlyMosaicBalances;
+import org.nem.nis.state.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -48,10 +47,10 @@ public class ExpiredMosaicController {
 		}
 
 		final BlockHeight height = heightBuilder.build();
-		final Collection<Map.Entry<MosaicId, ReadOnlyMosaicBalances>> expirations = this.expiredMosaicCache.findExpirationsAtHeight(height);
+		final Collection<ExpiredMosaicEntry> expirations = this.expiredMosaicCache.findExpirationsAtHeight(height);
 		return new SerializableList<>(
 			expirations.stream()
-				.map(pair -> new ExpiredMosaicViewModel(pair.getKey(), pair.getValue()))
+				.map(expiration -> new ExpiredMosaicViewModel(expiration))
 				.collect(Collectors.toList())
 		);
 	}

--- a/nis/src/main/java/org/nem/nis/controller/viewmodels/ExpiredMosaicViewModel.java
+++ b/nis/src/main/java/org/nem/nis/controller/viewmodels/ExpiredMosaicViewModel.java
@@ -15,24 +15,26 @@ import java.util.stream.Collectors;
 public class ExpiredMosaicViewModel implements SerializableEntity {
 	private final MosaicId mosaicId;
 	private final List<AddressBalancePair> balances;
+	private final ExpiredMosaicType expiredMosaicType;
 
 	/**
 	 * Creates a new expired mosaic view model.
 	 *
-	 * @param mosaicId Expired mosaic id.
-	 * @param mosaicBalances Balances at time of expiration.
+	 * @param entry Expired mosaic entry.
 	 */
-	public ExpiredMosaicViewModel(final MosaicId mosaicId, final ReadOnlyMosaicBalances mosaicBalances) {
-		this.mosaicId = mosaicId;
-		this.balances = mosaicBalances.getOwners()
+	public ExpiredMosaicViewModel(final ExpiredMosaicEntry entry) {
+		this.mosaicId = entry.getMosaicId();
+		this.balances = entry.getBalances().getOwners()
 			.stream()
-			.map(address -> new AddressBalancePair(address, mosaicBalances.getBalance(address)))
+			.map(address -> new AddressBalancePair(address, entry.getBalances().getBalance(address)))
 			.collect(Collectors.toList());
+		this.expiredMosaicType = entry.getExpiredMosaicType();
 	}
 
 	@Override
 	public void serialize(final Serializer serializer) {
 		serializer.writeObject("mosaicId", this.mosaicId);
+		serializer.writeInt("expiredMosaicType", this.expiredMosaicType.value());
 		serializer.writeObjectArray("balances", this.balances);
 	}
 

--- a/nis/src/main/java/org/nem/nis/secret/BlockTransactionObserverFactory.java
+++ b/nis/src/main/java/org/nem/nis/secret/BlockTransactionObserverFactory.java
@@ -79,7 +79,7 @@ public class BlockTransactionObserverFactory {
 		builder.add(new MultisigCosignatoryModificationObserver(accountStateCache));
 		builder.add(new MultisigMinCosignatoriesModificationObserver(accountStateCache));
 		builder.add(new TransactionHashesObserver(nisCache.getTransactionHashCache()));
-		builder.add(new ProvisionNamespaceObserver(nisCache.getNamespaceCache(), accountStateCache));
+		builder.add(new ProvisionNamespaceObserver(nisCache.getNamespaceCache(), accountStateCache, nisCache.getExpiredMosaicCache()));
 		builder.add(new MosaicDefinitionCreationObserver(nisCache.getNamespaceCache()));
 		builder.add(new MosaicSupplyChangeObserver(nisCache.getNamespaceCache(), accountStateCache));
 		builder.add(new MosaicTransferObserver(nisCache.getNamespaceCache()));

--- a/nis/src/main/java/org/nem/nis/secret/ExpiredNamespacesObserver.java
+++ b/nis/src/main/java/org/nem/nis/secret/ExpiredNamespacesObserver.java
@@ -60,7 +60,7 @@ public class ExpiredNamespacesObserver implements BlockTransactionObserver {
 
 			if (this.shouldTrackExpiredMosaics) {
 				if (NotificationTrigger.Execute == context.getTrigger()) {
-					this.expiredMosaicCache.addExpiration(context.getHeight(), mosaicId, mosaicEntry.getBalances());
+					this.expiredMosaicCache.addExpiration(context.getHeight(), mosaicId, mosaicEntry.getBalances(), ExpiredMosaicType.Expired);
 				} else {
 					this.expiredMosaicCache.removeAll(context.getHeight());
 				}

--- a/nis/src/main/java/org/nem/nis/secret/ProvisionNamespaceObserver.java
+++ b/nis/src/main/java/org/nem/nis/secret/ProvisionNamespaceObserver.java
@@ -2,7 +2,9 @@ package org.nem.nis.secret;
 
 import org.nem.core.model.namespace.*;
 import org.nem.core.model.observers.*;
+import org.nem.core.model.primitive.BlockHeight;
 import org.nem.nis.cache.*;
+import org.nem.nis.state.*;
 
 import java.util.*;
 
@@ -12,15 +14,20 @@ import java.util.*;
 public class ProvisionNamespaceObserver implements BlockTransactionObserver {
 	private final NamespaceCache namespaceCache;
 	private final AccountStateCache accountStateCache;
+	private final ExpiredMosaicCache expiredMosaicCache;
 
 	/**
 	 * Creates a new observer.
 	 *
-	 * @param namespaceCache The namespace cache.
+	 * @param namespaceCache Namespace cache.
+	 * @param accountStateCache Account state cache.
+	 * @param expiredMosaicCache Expired mosaic cache.
 	 */
-	public ProvisionNamespaceObserver(final NamespaceCache namespaceCache, final AccountStateCache accountStateCache) {
+	public ProvisionNamespaceObserver(final NamespaceCache namespaceCache, final AccountStateCache accountStateCache,
+			final ExpiredMosaicCache expiredMosaicCache) {
 		this.namespaceCache = namespaceCache;
 		this.accountStateCache = accountStateCache;
+		this.expiredMosaicCache = expiredMosaicCache;
 	}
 
 	@Override
@@ -37,21 +44,26 @@ public class ProvisionNamespaceObserver implements BlockTransactionObserver {
 			final Namespace namespace = new Namespace(notification.getNamespaceId(), notification.getOwner(), context.getHeight());
 			this.namespaceCache.add(namespace);
 			if (namespace.getId().isRoot()) {
-				this.updateAccountStates(namespace.getId());
+				this.updateAccountStates(namespace.getId(), context.getHeight());
 			}
 		} else {
 			this.namespaceCache.remove(notification.getNamespaceId());
 		}
 	}
 
-	private void updateAccountStates(final NamespaceId namespaceId) {
+	private void updateAccountStates(final NamespaceId namespaceId, final BlockHeight height) {
 		final Collection<NamespaceId> ids = new ArrayList<>();
 		ids.add(namespaceId);
 		ids.addAll(this.namespaceCache.getSubNamespaceIds(namespaceId));
 		ids.forEach(id -> {
 			NamespaceCacheUtils.getMosaicIds(this.namespaceCache, id).forEach(mosaicId -> {
-				NamespaceCacheUtils.getMosaicOwners(this.namespaceCache, mosaicId)
-						.forEach(owner -> this.accountStateCache.findStateByAddress(owner).getAccountInfo().addMosaicId(mosaicId));
+				final ReadOnlyMosaicEntry mosaicEntry = NamespaceCacheUtils.getMosaicEntry(this.namespaceCache, mosaicId);
+				final ReadOnlyMosaicBalances mosaicBalances = mosaicEntry.getBalances();
+
+				mosaicBalances.getOwners().forEach(owner ->
+					this.accountStateCache.findStateByAddress(owner).getAccountInfo().addMosaicId(mosaicId));
+
+				this.expiredMosaicCache.addExpiration(height, mosaicId, mosaicBalances, ExpiredMosaicType.Restored);
 			});
 		});
 	}

--- a/nis/src/main/java/org/nem/nis/state/ExpiredMosaicEntry.java
+++ b/nis/src/main/java/org/nem/nis/state/ExpiredMosaicEntry.java
@@ -1,0 +1,54 @@
+package org.nem.nis.state;
+
+import org.nem.core.model.Address;
+import org.nem.core.model.mosaic.*;
+import org.nem.core.model.primitive.*;
+
+/**
+ * An immutable expired mosaic entry.
+ */
+public class ExpiredMosaicEntry {
+	private final MosaicId mosaicId;
+	private final ReadOnlyMosaicBalances mosaicBalances;
+	private final ExpiredMosaicType expiredMosaicType;
+
+	/**
+	 * Creates a new expired mosaic entry.
+	 *
+	 * @param mosaicId Mosaic id.
+	 * @param mosaicBalances Mosaic balances.
+	 * @param expiredMosaicType Expired mosaic type.
+	 */
+	public ExpiredMosaicEntry(final MosaicId mosaicId, final ReadOnlyMosaicBalances mosaicBalances, final ExpiredMosaicType expiredMosaicType) {
+		this.mosaicId = mosaicId;
+		this.mosaicBalances = mosaicBalances;
+		this.expiredMosaicType = expiredMosaicType;
+	}
+
+	/**
+	 * Gets the mosaic id.
+	 *
+	 * @return Mosaic id.
+	 */
+	public MosaicId getMosaicId() {
+		return this.mosaicId;
+	}
+
+	/**
+	 * Gets the mosaic balances.
+	 *
+	 * @return Mosaic balances.
+	 */
+	public ReadOnlyMosaicBalances getBalances() {
+		return this.mosaicBalances;
+	}
+
+	/**
+	 * Gets the expired mosaic type.
+	 *
+	 * @return Expired mosaic type.
+	 */
+	public ExpiredMosaicType getExpiredMosaicType() {
+		return this.expiredMosaicType;
+	}
+}

--- a/nis/src/main/java/org/nem/nis/state/ExpiredMosaicType.java
+++ b/nis/src/main/java/org/nem/nis/state/ExpiredMosaicType.java
@@ -1,0 +1,32 @@
+package org.nem.nis.state;
+
+/**
+ * Enum containing types of expired mosaics.
+ */
+public enum ExpiredMosaicType {
+
+	/**
+	 * Mosaic has expired.
+	 */
+	Expired(1),
+
+	/**
+	 * Mosaic has been restored.
+	 */
+	Restored(2);
+
+	private final int value;
+
+	ExpiredMosaicType(final int value) {
+		this.value = value;
+	}
+
+	/**
+	 * Gets the underlying integer representation of the type.
+	 *
+	 * @return The underlying value.
+	 */
+	public int value() {
+		return this.value;
+	}
+}

--- a/nis/src/test/java/org/nem/nis/controller/ExpiredMosaicControllerTest.java
+++ b/nis/src/test/java/org/nem/nis/controller/ExpiredMosaicControllerTest.java
@@ -87,6 +87,14 @@ public class ExpiredMosaicControllerTest {
 
 		MatcherAssert.assertThat(balanceMap2.keySet(), IsEquivalent.equivalentTo(Collections.singletonList(address1)));
 		MatcherAssert.assertThat(balanceMap2.get(address1), IsEqual.equalTo(new Quantity(30000)));
+
+		// - check expired mosaic types (1 - expired, 2 - restored)
+		MatcherAssert.assertThat(
+			(Integer) jsonObject1.get("expiredMosaicType"),
+			IsEqual.equalTo(mosaicId1.equals(Utils.createMosaicId(222)) ? 1 : 2));
+		MatcherAssert.assertThat(
+			(Integer) jsonObject2.get("expiredMosaicType"),
+			IsEqual.equalTo(mosaicId1.equals(Utils.createMosaicId(222)) ? 2 : 1));
 	}
 
 	private MosaicId deserializeMosaicId(final JSONObject jsonObject) {
@@ -127,17 +135,17 @@ public class ExpiredMosaicControllerTest {
 			final DefaultExpiredMosaicCache copy = cache.copy();
 
 			final MosaicBalances balances1 = this.createMosaicBalancesWithSingleBalance(address1, 10000);
-			copy.addExpiration(new BlockHeight(122), Utils.createMosaicId(111), balances1);
+			copy.addExpiration(new BlockHeight(122), Utils.createMosaicId(111), balances1, ExpiredMosaicType.Expired);
 
 			final MosaicBalances balances2 = this.createMosaicBalancesWithSingleBalance(address1, 20000);
 			balances2.incrementBalance(address2, new Quantity(9999));
-			copy.addExpiration(new BlockHeight(123), Utils.createMosaicId(222), balances2);
+			copy.addExpiration(new BlockHeight(123), Utils.createMosaicId(222), balances2, ExpiredMosaicType.Expired);
 
 			final MosaicBalances balances3 = this.createMosaicBalancesWithSingleBalance(address1, 30000);
-			copy.addExpiration(new BlockHeight(123), Utils.createMosaicId(333), balances3);
+			copy.addExpiration(new BlockHeight(123), Utils.createMosaicId(333), balances3, ExpiredMosaicType.Restored);
 
 			final MosaicBalances balances4 = this.createMosaicBalancesWithSingleBalance(address1, 40000);
-			copy.addExpiration(new BlockHeight(124), Utils.createMosaicId(444), balances4);
+			copy.addExpiration(new BlockHeight(124), Utils.createMosaicId(444), balances4, ExpiredMosaicType.Expired);
 
 			copy.commit();
 			return cache;

--- a/nis/src/test/java/org/nem/nis/controller/viewmodels/ExpiredMosaicViewModelTest.java
+++ b/nis/src/test/java/org/nem/nis/controller/viewmodels/ExpiredMosaicViewModelTest.java
@@ -19,18 +19,20 @@ public class ExpiredMosaicViewModelTest {
 	@Test
 	public void canSerializeWithoutBalances() {
 		// Arrange:
-		final ExpiredMosaicViewModel viewModel = new ExpiredMosaicViewModel(
+		final ExpiredMosaicViewModel viewModel = new ExpiredMosaicViewModel(new ExpiredMosaicEntry(
 			new MosaicId(new NamespaceId("alice"), "tokens"),
-			new MosaicBalances());
+			new MosaicBalances(),
+			ExpiredMosaicType.Restored));
 
 		// Act:
 		final JSONObject jsonObject = JsonSerializer.serializeToJson(viewModel);
 
 		// Assert:
-		MatcherAssert.assertThat(jsonObject.size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(jsonObject.size(), IsEqual.equalTo(3));
 		MatcherAssert.assertThat(((JSONObject) jsonObject.get("mosaicId")).get("namespaceId"), IsEqual.equalTo("alice"));
 		MatcherAssert.assertThat(((JSONObject) jsonObject.get("mosaicId")).get("name"), IsEqual.equalTo("tokens"));
 		MatcherAssert.assertThat(((JSONArray) jsonObject.get("balances")).size(), IsEqual.equalTo(0));
+		MatcherAssert.assertThat(((Integer) jsonObject.get("expiredMosaicType")), IsEqual.equalTo(2));
 	}
 
 	@Test
@@ -45,16 +47,22 @@ public class ExpiredMosaicViewModelTest {
 		balances.incrementBalance(address2, new Quantity(333));
 		balances.incrementBalance(address3, new Quantity(222));
 
-		final ExpiredMosaicViewModel viewModel = new ExpiredMosaicViewModel(new MosaicId(new NamespaceId("alice"), "tokens"), balances);
+		final ExpiredMosaicViewModel viewModel = new ExpiredMosaicViewModel(new ExpiredMosaicEntry(
+			new MosaicId(new NamespaceId("alice"), "tokens"),
+			balances,
+			ExpiredMosaicType.Expired));
 
 		// Act:
 		final JSONObject jsonObject = JsonSerializer.serializeToJson(viewModel);
 
 		// Assert:
-		MatcherAssert.assertThat(jsonObject.size(), IsEqual.equalTo(2));
+		MatcherAssert.assertThat(jsonObject.size(), IsEqual.equalTo(3));
+
+		// - check mosaicId
 		MatcherAssert.assertThat(((JSONObject) jsonObject.get("mosaicId")).get("namespaceId"), IsEqual.equalTo("alice"));
 		MatcherAssert.assertThat(((JSONObject) jsonObject.get("mosaicId")).get("name"), IsEqual.equalTo("tokens"));
 
+		// - check balances
 		JSONArray jsonBalances = (JSONArray) jsonObject.get("balances");
 		MatcherAssert.assertThat(jsonBalances.size(), IsEqual.equalTo(3));
 
@@ -74,5 +82,8 @@ public class ExpiredMosaicViewModelTest {
 		MatcherAssert.assertThat(balanceMap.get(address1), IsEqual.equalTo(new Quantity(111)));
 		MatcherAssert.assertThat(balanceMap.get(address2), IsEqual.equalTo(new Quantity(333)));
 		MatcherAssert.assertThat(balanceMap.get(address3), IsEqual.equalTo(new Quantity(222)));
+
+		// - check expiredMosaicType
+		MatcherAssert.assertThat(((Integer) jsonObject.get("expiredMosaicType")), IsEqual.equalTo(1));
 	}
 }

--- a/nis/src/test/java/org/nem/nis/secret/ExpiredNamespacesObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/ExpiredNamespacesObserverTest.java
@@ -73,6 +73,11 @@ public class ExpiredNamespacesObserverTest {
 		// Assert: changes to expired mosaic cache because it's enabled
 		MatcherAssert.assertThat(context.expiredMosaicCache.size(), IsEqual.equalTo(1));
 		MatcherAssert.assertThat(context.expiredMosaicCache.deepSize(), IsEqual.equalTo(2));
+
+		// - all are marked with expired
+		final Collection<ExpiredMosaicEntry> expirations = context.expiredMosaicCache.findExpirationsAtHeight(new BlockHeight(NOTIFY_BLOCK_HEIGHT));
+		MatcherAssert.assertThat(expirations.size(), IsEqual.equalTo(2));
+		expirations.forEach(expiration -> MatcherAssert.assertThat(expiration.getExpiredMosaicType(), IsEqual.equalTo(ExpiredMosaicType.Expired)));
 	}
 
 	@Test
@@ -89,6 +94,11 @@ public class ExpiredNamespacesObserverTest {
 		// Assert: changes to expired mosaic cache because it's enabled
 		MatcherAssert.assertThat(context.expiredMosaicCache.size(), IsEqual.equalTo(1));
 		MatcherAssert.assertThat(context.expiredMosaicCache.deepSize(), IsEqual.equalTo(3));
+
+		// - all are marked with expired
+		final Collection<ExpiredMosaicEntry> expirations = context.expiredMosaicCache.findExpirationsAtHeight(new BlockHeight(NOTIFY_BLOCK_HEIGHT));
+		MatcherAssert.assertThat(expirations.size(), IsEqual.equalTo(3));
+		expirations.forEach(expiration -> MatcherAssert.assertThat(expiration.getExpiredMosaicType(), IsEqual.equalTo(ExpiredMosaicType.Expired)));
 	}
 
 	// endregion
@@ -266,9 +276,9 @@ public class ExpiredNamespacesObserverTest {
 		}
 
 		private void addExpiredMosaics(final BlockHeight height) {
-			this.expiredMosaicCache.addExpiration(height, this.mosaicDefinition1.getId(), new MosaicBalances());
-			this.expiredMosaicCache.addExpiration(height, this.mosaicDefinition2.getId(), new MosaicBalances());
-			this.expiredMosaicCache.addExpiration(height, this.mosaicDefinition3.getId(), new MosaicBalances());
+			this.expiredMosaicCache.addExpiration(height, this.mosaicDefinition1.getId(), new MosaicBalances(), ExpiredMosaicType.Expired);
+			this.expiredMosaicCache.addExpiration(height, this.mosaicDefinition2.getId(), new MosaicBalances(), ExpiredMosaicType.Restored);
+			this.expiredMosaicCache.addExpiration(height, this.mosaicDefinition3.getId(), new MosaicBalances(), ExpiredMosaicType.Expired);
 		}
 	}
 }

--- a/nis/src/test/java/org/nem/nis/state/ExpiredMosaicEntryTest.java
+++ b/nis/src/test/java/org/nem/nis/state/ExpiredMosaicEntryTest.java
@@ -1,0 +1,32 @@
+package org.nem.nis.state;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.*;
+import org.junit.*;
+import org.nem.core.model.Address;
+import org.nem.core.model.primitive.*;
+import org.nem.core.test.Utils;
+import org.nem.nis.test.RemoteLinkFactory;
+
+public class ExpiredMosaicEntryTest {
+
+	@Test
+	public void canCreateExpiredMosaicType() {
+		MatcherAssert.assertThat(ExpiredMosaicType.Expired.value(), IsEqual.equalTo(1));
+		MatcherAssert.assertThat(ExpiredMosaicType.Restored.value(), IsEqual.equalTo(2));
+	}
+
+	@Test
+	public void canCreateEntry() {
+		// Arrange:
+		final MosaicBalances balances = new MosaicBalances();
+
+		// Act:
+		final ExpiredMosaicEntry entry = new ExpiredMosaicEntry(Utils.createMosaicId(123), balances, ExpiredMosaicType.Restored);
+
+		// Assert:
+		MatcherAssert.assertThat(entry.getMosaicId(), IsEqual.equalTo(Utils.createMosaicId(123)));
+		MatcherAssert.assertThat(entry.getBalances(), IsSame.sameInstance(balances));
+		MatcherAssert.assertThat(entry.getExpiredMosaicType(), IsEqual.equalTo(ExpiredMosaicType.Restored));
+	}
+}


### PR DESCRIPTION
 problem: in NEM, expired mosaic balances can be restored upon renewal of an expired mosaic
          this behavior is not discoverable
solution: update /local/mosaics/expired to report these mosaics
          include a new 'expiredMosaicType' property in the output to differentiate expired and restored mosaics