### PR TITLE
[nis]: track balance resets due to description change as expirations

### DIFF
--- a/nis/src/main/java/org/nem/nis/cache/DefaultExpiredMosaicCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/DefaultExpiredMosaicCache.java
@@ -52,8 +52,15 @@ public class DefaultExpiredMosaicCache implements ExpiredMosaicCache, DeepCopyab
 	}
 
 	@Override
-	public void removeAll(final BlockHeight height) {
-		this.map.remove(height);
+	public void removeExpiration(final BlockHeight height, final MosaicId mosaicId) {
+		final ExpiredMosaicBlockGroup group = this.map.getOrDefault(height, null);
+		if (null != group) {
+			group.removeExpiredMosaic(mosaicId);
+
+			if (0 == group.expiredMosaicsCount()) {
+				this.map.remove(height);
+			}
+		}
 	}
 
 	// region DeepCopyableCache
@@ -106,6 +113,10 @@ public class DefaultExpiredMosaicCache implements ExpiredMosaicCache, DeepCopyab
 
 		public void addExpiredMosaic(final ExpiredMosaicEntry entry) {
 			this.expiredMosaicEntries.add(entry);
+		}
+
+		public void removeExpiredMosaic(final MosaicId mosaicId) {
+			this.expiredMosaicEntries.removeIf(entry -> entry.getMosaicId().equals(mosaicId));
 		}
 
 		@Override

--- a/nis/src/main/java/org/nem/nis/cache/ExpiredMosaicCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/ExpiredMosaicCache.java
@@ -19,9 +19,10 @@ public interface ExpiredMosaicCache extends ReadOnlyExpiredMosaicCache {
 	void addExpiration(final BlockHeight height, final MosaicId mosaicId, final ReadOnlyMosaicBalances balances, final ExpiredMosaicType expirationType);
 
 	/**
-	 * Removes all expirations at the specified height.
+	 * Removes a mosaic expiration.
 	 *
 	 * @param height Height of expiration.
+	 * @param mosaicId Id of expiring mosaic.
 	 */
-	void removeAll(final BlockHeight height);
+	void removeExpiration(final BlockHeight height, final MosaicId mosaicId);
 }

--- a/nis/src/main/java/org/nem/nis/cache/SynchronizedExpiredMosaicCache.java
+++ b/nis/src/main/java/org/nem/nis/cache/SynchronizedExpiredMosaicCache.java
@@ -51,9 +51,9 @@ public class SynchronizedExpiredMosaicCache implements ExpiredMosaicCache, DeepC
 	}
 
 	@Override
-	public void removeAll(final BlockHeight height) {
+	public void removeExpiration(final BlockHeight height, final MosaicId mosaicId) {
 		synchronized (this.lock) {
-			this.cache.removeAll(height);
+			this.cache.removeExpiration(height, mosaicId);
 		}
 	}
 

--- a/nis/src/main/java/org/nem/nis/secret/BlockTransactionObserverFactory.java
+++ b/nis/src/main/java/org/nem/nis/secret/BlockTransactionObserverFactory.java
@@ -80,7 +80,10 @@ public class BlockTransactionObserverFactory {
 		builder.add(new MultisigMinCosignatoriesModificationObserver(accountStateCache));
 		builder.add(new TransactionHashesObserver(nisCache.getTransactionHashCache()));
 		builder.add(new ProvisionNamespaceObserver(nisCache.getNamespaceCache(), accountStateCache, nisCache.getExpiredMosaicCache()));
-		builder.add(new MosaicDefinitionCreationObserver(nisCache.getNamespaceCache()));
+		builder.add(new MosaicDefinitionCreationObserver(
+			nisCache.getNamespaceCache(),
+			nisCache.getExpiredMosaicCache(),
+			this.forkConfiguration.getMosaicRedefinitionForkHeight()));
 		builder.add(new MosaicSupplyChangeObserver(nisCache.getNamespaceCache(), accountStateCache));
 		builder.add(new MosaicTransferObserver(nisCache.getNamespaceCache()));
 

--- a/nis/src/main/java/org/nem/nis/secret/ExpiredNamespacesObserver.java
+++ b/nis/src/main/java/org/nem/nis/secret/ExpiredNamespacesObserver.java
@@ -62,7 +62,7 @@ public class ExpiredNamespacesObserver implements BlockTransactionObserver {
 				if (NotificationTrigger.Execute == context.getTrigger()) {
 					this.expiredMosaicCache.addExpiration(context.getHeight(), mosaicId, mosaicEntry.getBalances(), ExpiredMosaicType.Expired);
 				} else {
-					this.expiredMosaicCache.removeAll(context.getHeight());
+					this.expiredMosaicCache.removeExpiration(context.getHeight(), mosaicId);
 				}
 			}
 

--- a/nis/src/main/java/org/nem/nis/secret/MosaicDefinitionCreationObserver.java
+++ b/nis/src/main/java/org/nem/nis/secret/MosaicDefinitionCreationObserver.java
@@ -1,23 +1,33 @@
 package org.nem.nis.secret;
 
-import org.nem.core.model.mosaic.MosaicDefinition;
+import org.nem.core.model.mosaic.*;
 import org.nem.core.model.observers.*;
-import org.nem.nis.cache.NamespaceCache;
-import org.nem.nis.state.Mosaics;
+import org.nem.core.model.primitive.BlockHeight;
+import org.nem.nis.cache.*;
+import org.nem.nis.state.*;
 
 /**
  * An observer that updates mosaic definition information.
  */
 public class MosaicDefinitionCreationObserver implements BlockTransactionObserver {
 	private final NamespaceCache namespaceCache;
+	private final ExpiredMosaicCache expiredMosaicCache;
+	private final BlockHeight mosaicRedefinitionForkHeight;
 
 	/**
 	 * Creates a new observer.
 	 *
-	 * @param namespaceCache The namespace cache.
+	 * @param namespaceCache Namespace cache.
+	 * @param expiredMosaicCache Expired mosaic cache.
+	 * @param mosaicRedefinitionForkHeight Mosaic redefinition fork height.
 	 */
-	public MosaicDefinitionCreationObserver(final NamespaceCache namespaceCache) {
+	public MosaicDefinitionCreationObserver(
+			final NamespaceCache namespaceCache,
+			final ExpiredMosaicCache expiredMosaicCache,
+			final BlockHeight mosaicRedefinitionForkHeight) {
 		this.namespaceCache = namespaceCache;
+		this.expiredMosaicCache = expiredMosaicCache;
+		this.mosaicRedefinitionForkHeight = mosaicRedefinitionForkHeight;
 	}
 
 	@Override
@@ -31,11 +41,24 @@ public class MosaicDefinitionCreationObserver implements BlockTransactionObserve
 
 	private void notify(final MosaicDefinitionCreationNotification notification, final BlockNotificationContext context) {
 		final MosaicDefinition mosaicDefinition = notification.getMosaicDefinition();
-		final Mosaics mosaics = this.namespaceCache.get(mosaicDefinition.getId().getNamespaceId()).getMosaics();
+		final MosaicId mosaicId = mosaicDefinition.getId();
+
+		final Mosaics mosaics = this.namespaceCache.get(mosaicId.getNamespaceId()).getMosaics();
 		if (NotificationTrigger.Execute == context.getTrigger()) {
+			if (context.getHeight().compareTo(this.mosaicRedefinitionForkHeight) < 0) {
+				final MosaicEntry mosaicEntry = mosaics.get(mosaicId);
+				if (null != mosaicEntry) {
+					this.expiredMosaicCache.addExpiration(context.getHeight(), mosaicId, mosaicEntry.getBalances(), ExpiredMosaicType.Expired);
+				}
+			}
+
 			mosaics.add(mosaicDefinition, context.getHeight());
 		} else {
-			mosaics.remove(mosaicDefinition.getId());
+			mosaics.remove(mosaicId);
+
+			if (context.getHeight().compareTo(this.mosaicRedefinitionForkHeight) < 0) {
+				this.expiredMosaicCache.removeExpiration(context.getHeight(), mosaicId);
+			}
 		}
 	}
 }

--- a/nis/src/test/java/org/nem/nis/secret/AccountInfoMosaicIdsObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/AccountInfoMosaicIdsObserverTest.java
@@ -200,6 +200,7 @@ public class AccountInfoMosaicIdsObserverTest {
 		private final ForkConfiguration forkConfiguration = new ForkConfiguration.Builder().build();
 		private final DefaultNamespaceCache namespaceCache = new DefaultNamespaceCache(forkConfiguration.getMosaicRedefinitionForkHeight())
 				.copy();
+		private final ExpiredMosaicCache expiredMosaicCache = new DefaultExpiredMosaicCache().copy();
 		private final AccountStateCache accountStateCache = new DefaultAccountStateCache().copy();
 
 		public TestContext() {
@@ -215,7 +216,7 @@ public class AccountInfoMosaicIdsObserverTest {
 		private BlockTransactionObserver createObserver() {
 			// note that this observer is dependent on MosaicDefinitionCreationObserver and MosaicTransferObserver
 			final AggregateBlockTransactionObserverBuilder builder = new AggregateBlockTransactionObserverBuilder();
-			builder.add(new MosaicDefinitionCreationObserver(this.namespaceCache));
+			builder.add(new MosaicDefinitionCreationObserver(this.namespaceCache, this.expiredMosaicCache, this.forkConfiguration.getMosaicRedefinitionForkHeight()));
 			builder.add(new MosaicTransferObserver(this.namespaceCache));
 			builder.add(new AccountInfoMosaicIdsObserver(this.namespaceCache, this.accountStateCache));
 			return builder.build();

--- a/nis/src/test/java/org/nem/nis/secret/ExpiredNamespacesObserverTest.java
+++ b/nis/src/test/java/org/nem/nis/secret/ExpiredNamespacesObserverTest.java
@@ -152,7 +152,6 @@ public class ExpiredNamespacesObserverTest {
 		notify(observer, NotificationTrigger.Undo);
 
 		// Assert: changes to expired mosaic cache because it's enabled
-		//         [notice specific mosaicId(s) don't matter, only those expirations at matching height are removed]
 		MatcherAssert.assertThat(context.expiredMosaicCache.size(), IsEqual.equalTo(2));
 		MatcherAssert.assertThat(context.expiredMosaicCache.deepSize(), IsEqual.equalTo(6));
 	}


### PR DESCRIPTION
    [nis]: update MosaicDefinitionCreationObserver to track expirations
    
     problem: prior to mosaic redefinition fork, a mosaic description change
              would effectively zero all balances
    solution: update MosaicDefinitionCreationObserver to track these
              balance resets as mosaic expirations


    [nis]: replace ExpiredMosaicCache.removeAll with ExpiredMosaicCache.removeExpiration
    
     problem: handling of mosaic description changes prior to the mosaic redefinition fork height
              requires the ability to remove a specific mosaic at a specific height
    solution: replace removeAll with removeExpiration
              update ExpiredNamespacesObserver