### PR TITLE
[mkdocs] docs: add accounts and cryptography concepts

### DIFF
--- a/mkdocs/config/mkdocs.en.yml
+++ b/mkdocs/config/mkdocs.en.yml
@@ -78,4 +78,6 @@ nav:
           - WebSockets: devbook/reference/websockets/index.md
   - Textbook:
       - textbook/intro.md
+      - textbook/cryptography.md
+      - textbook/accounts.md
       - textbook/glossary.md

--- a/mkdocs/pages/en/textbook/accounts.md
+++ b/mkdocs/pages/en/textbook/accounts.md
@@ -1,0 +1,163 @@
+# Accounts
+
+Account
+:   A secure place where digital assets like cryptocurrencies or <NFTs:> can be stored.
+    It functions similarly to a safe deposit box in traditional banking.
+
+In the case of blockchain, accounts are secured by a <key pair:>: assets can only be **transferred out** of an account
+by using its private key, but the public key can be shared freely in order to **receive** assets.
+
+Public keys are commonly shared as an <address:> for convenience, so the terms "account" and "address" are used as
+synonyms.
+
+Besides managing digital assets, accounts also represent the ownership of a private key, and act as a form of digital
+identity.
+On a blockchain, accounts can authorize transactions, configure permissions, and participate in <consensus:> mechanisms.
+
+!!! note "Account Lifecycle"
+
+    Accounts become active the first time they interact with the blockchain, for example, by receiving assets.
+    Prior to activation, no information about them is recorded on-chain and they do not appear in block explorers.
+
+    Once activated, an account can be emptied of assets, but it cannot be deleted from the blockchain.
+
+## Mnemonics
+
+Mnemonic Phrase
+:   A human-readable representation of a <private key:>, typically shown as a list of 12 or 24 random words.
+
+It is also called just mnemonic, and often used when creating or restoring accounts in <HD Wallets:>.
+
+NEM uses the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) standard that requires
+24 English words.
+
+!!! warning "Treat mnemonics as if they were private keys"
+
+    Access to a mnemonic phrase provides full access to all accounts generated from it.
+    Never share it, and avoid storing it unencrypted in digital form.
+
+## Wallets
+
+Wallet
+:   An application used to manage NEM accounts, initiate <transactions:> and sign them.
+
+It stores <private keys:> or <mnemonic phrases:>, and uses them to sign transactions.
+More broadly, wallets provide tools for exploring and interacting with the blockchain.
+
+Wallets can be:
+
+* :material-application-outline: **Software wallets**
+
+    Applications installed on desktop or mobile devices.
+
+    These typically offer the full range of functionality, at an increased security risk:
+    the software wallet must be online in order to interact with the blockchain, exposing the stored private keys to
+    potential compromise, even if protected by a password.
+
+* :material-integrated-circuit-chip: **Hardware wallets**
+
+    External physical devices that store keys offline.
+
+    These are designed primarily for secure transaction signing and must be connected to a software wallet to operate.
+
+    The private keys they contain never leave the device except when explicitly backed up, making hardware wallets
+    significantly more secure.
+
+Most wallets allow managing multiple accounts, QR code scanning (for signing and requesting transaction signatures),
+and <multisignature account:|multisig> configuration.
+Accounts can be also imported or exported using either <private keys:> or <mnemonic phrases:>.
+
+## HD Wallets
+
+HD Wallet
+:   A Hierarchical Deterministic (HD) <wallet:> derives a series of <accounts:> from a single seed,
+    which is more convenient than having to manage multiple <key pairs:>.
+
+This greatly simplifies the management of multiple accounts, but extra caution must be taken to keep the seed safe
+because compromising the seed compromises all the accounts derived from it.
+The seed is typically a <mnemonic phrase:>.
+
+Most wallets are HD wallets.
+
+NEM uses the [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) standard to generate accounts from
+the seed.
+
+## Multisignature Accounts
+
+Multisignature Account
+:   An <account:> (called **multisig**) requiring signature from multiple parties (called **cosignatories**) to
+    approve transactions.
+
+Multisig accounts are configured by:
+
+* Defining the list of cosignatories.
+* Setting the **minimum number of cosignatories** (**M**) out of the total (**N**) required to authorize a transaction.
+    This is known as an **M-of-N** multisig.
+    Setting **M** equal to **N** (an **N-of-N** multisig) requires every cosignatory to sign.
+
+For example, a **2-of-3** multisig has three cosignatories, any two of which must sign to authorize a transaction:
+
+```dot
+digraph "M-of-N Multisignature" {
+    rankdir="BT";
+    node [fontsize=12];
+    "Multisig Account" [label="Multisig Account\n2 of 3"];
+
+    "Cosignatory 1" [penwidth=2];
+    "Cosignatory 2" [penwidth=2];
+
+    "Cosignatory 1" -> "Multisig Account" [penwidth=2 minlen=2];
+    "Cosignatory 2" -> "Multisig Account" [penwidth=2 minlen=2];
+    "Cosignatory 3" -> "Multisig Account" [style=dashed minlen=2];
+}
+```
+
+In the previous diagram, Cosignatories 1 and 2 sign, which meets the minimum of `M=2`, so the transaction is valid
+without Cosignatory 3.
+
+### Use cases
+
+* **Shared control over funds or functionality**.
+
+    No action can be performed on the account without approval from the configured number of cosignatories.
+
+    This also mitigates the risk of one of the accounts being compromised.
+
+* **Multifactor authorization**.
+
+    As a security measure, users can create a multisig so that they need to approve transactions from multiple devices.
+
+* **Account ownership transfer**.
+
+    Transferring private keys is not a viable mechanism to change ownership of an account,
+    because the receiver can never be sure that the sender has deleted their copy of the keys.
+
+    To solve this issue, the sender can configure the transferred account as a 1-of-1 multisig,
+    and set the receiver account as the only cosignatory.
+
+    The account can be transferred again by changing the single cosignatory as many times as needed.
+
+### Constraints
+
+Bear in mind the following when designing multisignature solutions:
+
+* **Maximum number of cosignatories for an account**.
+
+    A multisig account can have at most **32** cosignatories.
+
+* **Removing cosignatories has special rules**.
+
+    Removing a cosignatory does not require their own signature.
+    For example, a removal in a **3-of-5** multisig needs at least 3 signatures from the 4 remaining cosignatories,
+    but a removal in a **5-of-5** multisig needs all 4 remaining signatures.
+
+    A single transaction can remove **at most one** cosignatory.
+    Removing several requires separate transactions.
+
+    The last remaining cosignatory can remove themselves, which dissolves the multisig.
+
+* **No nested multisigs**.
+
+    In NEM, a multisig account cannot itself be a cosignatory of another multisig, and a cosignatory account cannot
+    be converted into a multisig.
+    Multisig hierarchies are therefore **one layer deep**.

--- a/mkdocs/pages/en/textbook/cryptography.md
+++ b/mkdocs/pages/en/textbook/cryptography.md
@@ -1,0 +1,153 @@
+# Basic Cryptography
+
+These are the basic cryptography concepts that underpin NEM's technology.
+
+## Hashes
+
+Hash
+:   A cryptographic hash is a fixed-size string of characters produced by a mathematical function
+    (called a _hash function_) that maps input data of any size to a unique output.
+
+Several such functions exist, such as [Keccak](https://keccak.team/keccak.html) or
+[RIPEMD-160](https://en.wikipedia.org/wiki/RIPEMD), but they all share the same essential properties:
+
+* **Determinism**: The same input always produces the same hash.
+* **Collision resistance**: It is extremely difficult to find two different inputs that produce the same hash.
+* **Irreversibility**: The original input cannot be reconstructed from the hash.
+
+These properties are critical for ensuring data integrity, verifying authenticity,
+and linking <blocks:> together in a blockchain.
+
+NEM uses **Keccak-256**, **Keccak-512**, and **RIPEMD-160** across key derivation, address generation, signing, and
+block hashing.
+
+!!! warning "NEM uses Keccak, not SHA-3"
+
+    NEM adopted Keccak before it was finalized as SHA-3.
+    The two algorithms use different padding and therefore produce different outputs for the same input.
+    As a result, a standard SHA-3 library cannot verify NEM signatures or regenerate NEM addresses.
+    A Keccak implementation such as [Bouncy Castle](https://www.bouncycastle.org/) is required instead.
+
+    NEM's Java source names its helper methods `sha3_256` and `sha3_512`, but both internally call
+    `Keccak-*`.
+    The `sha3_` prefix is historical and does not refer to the final SHA-3 specification.
+
+## Keys
+
+Private Key
+:   A very long, secret number.
+    The actual value of the private key is meaningless, and it is meant to be kept secret.
+    It should be impossible to guess by unauthorized parties, and, although it is commonly randomly-generated,
+    it is extremely unlikely that the same number is generated twice by chance.
+
+NEM private keys are 32 bytes long, typically represented as 64-character hexadecimal strings.
+
+Public Key
+:   A very long number that serves as the public identifier of a <private key:> and can be disseminated widely.
+    It can be used to prove that the private key is known without revealing it.
+
+    Although mathematically derived from the private key, the reverse operation is practically impossible with
+    current technology.
+
+NEM public keys are 32 bytes long, typically represented as 64-character hexadecimal strings.
+
+Key Pair
+:   A matched set consisting of a <private key:> and its corresponding <public key:>.
+    The private key is kept secret by the owner, while the public key is distributed openly.
+    Together, they enable secure cryptographic operations such as digital signatures and encryption.
+
+NEM uses key pairs in two places:
+
+Main Key
+:   <Key pair:|Key pair> associated with every <account:>, identifying its owner.
+
+Remote Key
+:   Key pair associated with an account that has delegated harvesting to a remote node (see <harvesting:>).
+    The remote key signs blocks on behalf of the main account without exposing the main private key.
+
+??? warning "Key Security"
+
+    The **private key** in any key pair should be kept secret at all times.
+
+    However, the severity of having a secret key revealed depends on the purpose of that key:
+
+    | Key        | Severity | Impact |
+    | ---------- | -------- | ------ |
+    | **Main**   | 🔴 HIGH  | Assets can be transferred out of the account. |
+    | **Remote** | 🟠 MED   | Harmless to the delegating account's funds. An attacker gathering a large number of remote keys could gain substantial harvesting power and influence which blocks are added to the blockchain. Easily reverted by linking another remote account. |
+
+On NEM, both the private and the public key are 256-bit (32-byte) integers.
+The public key is obtained via [Elliptic Curve Cryptography](https://en.wikipedia.org/wiki/Elliptic-curve_cryptography)
+using [Ed25519](https://ed25519.cr.yp.to), which is defined over a
+[twisted Edwards curve](https://en.wikipedia.org/wiki/Twisted_Edwards_curve).
+
+## Signatures
+
+Signature
+:   A digital attachment to a document that certifies that the document is approved by a given <account:>.
+
+The signature is obtained by processing the document with the <private key:> of the account,
+so that anybody can use the associated public key to verify that the signature matches the document,
+but only the owner of the private key can produce an identical signature.
+
+All transactions on NEM are signed, but the signatures required depend on the transaction type and its participants.
+For example, transferring assets from a single-owner account to another only requires the signature of the
+source account's private key.
+
+However, transferring assets from a <multisignature account:|multiple-owner account> requires the approval of enough
+cosignatories to meet the multisig threshold, and must therefore gather multiple signatures before it is considered
+valid.
+
+Signatures on NEM are 512-bit (64-byte) long and are generated using the [Ed25519](https://ed25519.cr.yp.to) algorithm
+with the **Keccak-512** hash function.
+
+## Addresses
+
+Address
+:   A convenient, shorter form of a <public key:>, that simplifies sharing it by requiring only
+    letters and numbers. It's typically a synonym for <account:>.
+
+Keys, both public and private, are binary data which is hard to print and share, whereas addresses are made up of
+only latin letters and numbers.
+
+Moreover, NEM keys require 32 bytes of binary data, or 64 hexadecimal characters.
+Addresses, on the other hand, only require 40 characters, reaching a compromise between length and practicality.
+
+On NEM, addresses are obtained from public keys by:
+
+1. Applying [Keccak-256](https://keccak.team/keccak.html) to the public key to produce a 32-byte hash.
+2. Applying [RIPEMD-160](https://en.wikipedia.org/wiki/RIPEMD) to the result to produce a 20-byte hash.
+3. Generating a 25-byte **raw address** by joining:
+
+    * A 1-byte network version: `0x68` for <mainnet:> (`N`), `0x98` for <testnet:> (`T`), or `0x60` for
+        <mijinnet:> (`M`).
+    * The 20-byte RIPEMD-160 hash from step 2.
+    * A 4-byte checksum to detect mistyped addresses, computed as the first 4 bytes of the `Keccak-256` hash of the
+        previous 21 bytes (network version + RIPEMD-160 hash).
+
+4. Generating a 40-character **encoded address** by [Base32-encoding](https://en.wikipedia.org/wiki/Base32) the raw
+    address.
+
+    The encoded address is the most common way of sharing addresses because it only uses uppercase letters and digits.
+
+    Example: `NBHK6WHL5TGBMCLVW4RSFMRO4ZYXCJFRAVO2B4FU`
+
+5. Optionally, for easier reading, hyphens can be added every 6 characters to create a 46-character **pretty address**.
+
+    Example: `NBHK6W-HL5TGB-MCLVW4-RSFMRO-4ZYXCJ-FRAVO2-B4FU`
+
+!!! note "Address generation is an offline process"
+
+    Note that address generation does not require interaction with the blockchain.
+
+    In fact, NEM only tracks addresses and associated public keys when they first appear in a transaction.
+
+## Vanity addresses
+
+While keys, and therefore <addresses:> too, are normally generated randomly, it is possible to create
+**vanity addresses** that include specific patterns or prefixes.
+
+This involves generating <key pairs:> repeatedly until one produces an address that meets the desired criteria.
+The process usually requires substantial time and computation depending on the complexity of the pattern.
+
+Vanity addresses can be useful for branding, visibility, or personal preference, but they offer no security advantage.

--- a/mkdocs/pages/en/textbook/glossary.md
+++ b/mkdocs/pages/en/textbook/glossary.md
@@ -1,7 +1,8 @@
 # Glossary
 
 AMA
-:   Ask Me Anything. An open questions session.
+:   Ask Me Anything.
+    An open questions session.
 
 AML
 :   Anti Money Laundering.
@@ -13,13 +14,16 @@ APR
 :   Annual Percentage Rate.
 
 Arbitrage
-:   When a trader purchases an asset in a market and sells it in a different one, to profit from a deviation in prices between markets.
+:   When a trader purchases an asset in a market and sells it in a different one, to profit from a deviation in prices
+    between markets.
 
 Backrunning
-:   To broadcast ``transactionA`` with slightly lower gas (or fees) than an already pending ``transactionB`` so that ``transactionA`` gets mined *right after* ``transactionB`` in the same block.
+:   To broadcast ``transactionA`` with slightly lower gas (or fees) than an already pending ``transactionB`` so that
+    ``transactionA`` gets mined *right after* ``transactionB`` in the same block.
 
 BLS
-:   A [Boneh–Lynn–Shacham](https://en.wikipedia.org/wiki/BLS_digital_signature) signature is a cryptographic signature scheme which allows a user to verify that a signer is authentic.
+:   A [Boneh–Lynn–Shacham](https://en.wikipedia.org/wiki/BLS_digital_signature) signature is a cryptographic signature
+    scheme which allows a user to verify that a signer is authentic.
 
 BTC
 :   Bitcoin.
@@ -31,7 +35,7 @@ CEX
 :   Centralized Exchange, as opposed to Decentralized Exchanges (<DEX:>).
 
 CLI
-:   Command-Line Interface. A Program which is entirely used from a terminal console, using only the keyboard. Symbol has a CLI tool to interact with the blockchain.
+:   Command-Line Interface. A Program which is entirely used from a terminal console, using only the keyboard.
 
 CMC
 :   Coin Market Cap. A web page with cryptocurrency information.
@@ -40,11 +44,13 @@ CSD
 :   Central Securities Deposit.
 
 DAO
-:   Decentralized Autonomous Organization. An organization whose governance happens completely on a blockchain.
+:   Decentralized Autonomous Organization.
+    An organization whose governance happens completely on a blockchain.
 
 Dapp
 :   Decentralized Application. An application that runs on a blockchain instead of a single computer.
-    The term is slightly abused so, in a more general sense, it also means any application which makes use of a blockchain.
+    The term is slightly abused so, in a more general sense, it also means any application which makes use of a
+    blockchain.
 
 DDH
 :   Decisional [Diffie-Hellman](https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange).
@@ -59,7 +65,8 @@ DEX
 :   Decentralized Exchange, as opposed to traditional Centralized Exchanges (<CEX:>).
 
 DoS
-:   Denial of Service. An attack in which a single source floods a server or network with excessive requests,
+:   Denial of Service.
+    An attack in which a single source floods a server or network with excessive requests,
     overwhelming its resources and rendering it unable to respond to legitimate traffic.
 
     The most common variant is the DDoS (Distributed Denial of Service) attack that involves multiple sources,
@@ -75,7 +82,9 @@ EMEA
 :   Europe, Middle-East and Africa.
 
 ERC
-:   Ethereum Request for Comment. Commonly utilized to refer to a token standard on the EVM (such as ERC-20, ERC-721, or ERC-1155).
+:   Ethereum Request for Comment.
+    Commonly utilized to refer to a token standard on the EVM
+    (such as ERC-20, ERC-721, or ERC-1155).
 
 ETH
 :   Ethereum.
@@ -87,7 +96,8 @@ FFT
 :   [Fast Fourier Transform](https://en.wikipedia.org/wiki/Fast_Fourier_transform).
 
 Frontrunning
-:   To broadcast ``transactionA`` with slightly higher gas (or fees) than an already pending ``transactionB`` so that ``transactionA`` gets mined *right before* ``transactionB`` in the same block.
+:   To broadcast ``transactionA`` with slightly higher gas (or fees) than an already pending
+    ``transactionB`` so that ``transactionA`` gets mined *right before* ``transactionB`` in the same block.
     This is important in case of <DeFi:> markets, where gains can be made from frontrunning.
 
 Hardware wallet
@@ -122,11 +132,15 @@ LATAM
 :   Latin America (Central and South America).
 
 mainnet
-:   Symbol's Main Network, where transactions with real value happen, as opposed to the <testnet:>.
+:   NEM's Main Network, where transactions with real value happen, as opposed to the <testnet:>.
 
 MEV
 :   Miner-Extractable Value, or Maximal-Extractable Value, is the process of reorganizing transactions inside a block
     by miners, to gain *something*. Uses <Frontrunning:>, <Backrunning:>, or <Sandwich:>.
+
+mijinnet
+:   A permissioned NEM network originally intended for enterprise deployments, distinct from the public
+    <mainnet:> and <testnet:>.
 
 NAM
 :   North America.
@@ -146,15 +160,11 @@ PoC
 
 PoI
 :   Proof of Importance.
-    The consensus protocol used by <NIS1:>. Similar to <PoS:> but measuring an account's activity besides its stake.
+    The consensus protocol used by NEM.
+    Similar to <PoS:> but measuring an account's activity besides its stake.
 
 PoS
 :   Proof of Stake. A consensus protocol, used, for example, by Ethereum.
-
-PoS+
-:   Proof-of-Stake Plus. Symbol's consensus mechanism.
-    It is a modified <PoS:> algorithm which considers users' activity in the network in addition to their network stakes.
-    The chance that accounts will have to <harvesting:|harvest> a block is calculated through their <importance:> score.
 
 PoW
 :   Proof of Work. A consensus protocol, used, for example, by Bitcoin.
@@ -182,7 +192,7 @@ Sybil Attack
     Common countermeasures include <PoW:> or <PoS:>, which tie influence to scarce resources.
 
 testnet
-:   Symbol's Test Network, intended for development. Test <XYM:> can be freely obtained from a
+:   NEM's Test Network, intended for development. Test <XYM:> can be freely obtained from a
     [faucet](../devbook/accounts/testnet-faucet.md), so transactions on this network do not have real value,
     as opposed to transactions on the <mainnet:>.
 
@@ -193,7 +203,8 @@ TLS
 :   Security protocol used to encrypting communication between peers on a network.
 
 Token
-:   A representation of a digital asset. On Symbol they are called <mosaics:>.
+:   A representation of a digital asset.
+    On NEM they are called <mosaics:>.
 
 TPS
 :   Transactions Per Second.
@@ -207,14 +218,14 @@ USP
 
 VPS
 :   Virtual Private Server.
-    A virtual machine typically hosted on a data center which can be accessed remotely and treated as if it was
-    a conventional physical machine.
+    A virtual machine typically hosted on a data center which can be accessed remotely and treated as if it was a
+    conventional physical machine.
 
 VRF
 :   Verifiable Random Function.
 
 XEM
-:   The native currency of the <NIS1:> blockchain.
+:   The native currency of the NEM blockchain.
 
 XYM
 :   The native currency of the Symbol blockchain.


### PR DESCRIPTION
Adapts [Cryptography](https://docs.symboltest.net/en/textbook/cryptography/) and [Accounts](https://docs.symboltest.net/en/textbook/accounts/) concepts to NEM technology.

Differences with Symbol:                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                              
  * **Hash**: NEM uses Keccak-256 / Keccak-512; Symbol uses SHA-3 and SHA-512.
  * **Signatures**: Both use Ed25519, but NEM signs over Keccak-512 while Symbol signs over SHA-512.
  * **Addresses**: NEM addresses are 25 raw bytes / 40 Base32 characters with a 4-byte checksum; Symbol addresses are 24 bytes / 39 characters with a 3-byte checksum.
  * **Multisig**: NEM allows at most **32** cosignatories and is **one layer deep**; Symbol allows up to **25** cosignatories but supports **nested** multisig (up to 3 layers).