### PR TITLE
[mkdocs] docs: add serialization reference

### DIFF
--- a/mkdocs/config/mkdocs.base.yml
+++ b/mkdocs/config/mkdocs.base.yml
@@ -72,7 +72,7 @@ markdown_extensions:
     line_spans: __span
   pymdownx.inlinehilite: {}
   pymdownx.snippets:
-    base_path: !relative $config_dir/../overrides
+    base_path: !relative $config_dir/../snippets
     check_paths: true
   pymdownx.superfences: {}
   pymdownx.tabbed:

--- a/mkdocs/pages/en/devbook/reference/serialization/index.md
+++ b/mkdocs/pages/en/devbook/reference/serialization/index.md
@@ -5,6 +5,212 @@ hide:
 
 # Serialization
 
+## Basic Types
+
+<div class="big-table3">
+   <div id="amount"><b>Amount</b></div>
+   <div>8&nbsp;ubytes</div>
+   <div class="description"><p>A quantity of mosaics in absolute units. It can only be positive or zero. </p></div>
+   <div id="height"><b>Height</b></div>
+   <div>8&nbsp;ubytes</div>
+   <div class="description"><p>Index of a block in the blockchain. The first block (the Nemesis block) has height 1 and each subsequent block increases height by 1. </p></div>
+   <div id="timestamp"><b>Timestamp</b></div>
+   <div>4&nbsp;ubytes</div>
+   <div class="description"><p>Number of seconds elapsed since the creation of the Nemesis block. </p></div>
+   <div id="address"><b>Address</b></div>
+   <div>40&nbsp;ubytes</div>
+   <div class="description"><p>An address identifies an account and is derived from its <a href="#publickey" title="A 32-byte (256 bit) integer derived from a private key. It serves as the public identifier of the key pair and can be disseminated widely. It is used to prove that an entity was signed with the paired private key.">PublicKey</a>. The 40 bytes correspond to its Base32-encoded form. </p></div>
+   <div id="hash256"><b>Hash256</b></div>
+   <div>32&nbsp;ubytes</div>
+   <div class="description"><p>A 32-byte (256 bit) hash. The exact algorithm is unspecified as it can change depending on where it is used. </p></div>
+   <div id="publickey"><b>PublicKey</b></div>
+   <div>32&nbsp;ubytes</div>
+   <div class="description"><p>A 32-byte (256 bit) integer derived from a private key. It serves as the public identifier of the key pair and can be disseminated widely. It is used to prove that an entity was signed with the paired private key. </p></div>
+   <div id="signature"><b>Signature</b></div>
+   <div>64&nbsp;ubytes</div>
+   <div class="description"><p>A 64-byte (512 bit) array certifying that the signed data has not been modified. NEM uses Ed25519 signatures with the Keccak-512 hash function. </p></div>
+</div>
+
+## Enumerations
+
+<a id="networktype"></a>
+
+--8<-- 'devbook/reference/serialization/NetworkType.html'
+
+<a id="transactiontype"></a>
+
+--8<-- 'devbook/reference/serialization/TransactionType.html'
+
+<a id="linkaction"></a>
+
+--8<-- 'devbook/reference/serialization/LinkAction.html'
+
+<a id="mosaictransferfeetype"></a>
+
+--8<-- 'devbook/reference/serialization/MosaicTransferFeeType.html'
+
+<a id="mosaicsupplychangeaction"></a>
+
+--8<-- 'devbook/reference/serialization/MosaicSupplyChangeAction.html'
+
+<a id="multisigaccountmodificationtype"></a>
+
+--8<-- 'devbook/reference/serialization/MultisigAccountModificationType.html'
+
+<a id="messagetype"></a>
+
+--8<-- 'devbook/reference/serialization/MessageType.html'
+
+<a id="blocktype"></a>
+
+--8<-- 'devbook/reference/serialization/BlockType.html'
+
+## Structures
+
+<a id="transaction"></a>
+
+--8<-- 'devbook/reference/serialization/Transaction.html'
+
+<a id="nonverifiabletransaction"></a>
+
+--8<-- 'devbook/reference/serialization/NonVerifiableTransaction.html'
+
+<a id="accountkeylinktransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/AccountKeyLinkTransactionV1.html'
+
+<a id="nonverifiableaccountkeylinktransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/NonVerifiableAccountKeyLinkTransactionV1.html'
+
+<a id="namespaceid"></a>
+
+--8<-- 'devbook/reference/serialization/NamespaceId.html'
+
+<a id="mosaicid"></a>
+
+--8<-- 'devbook/reference/serialization/MosaicId.html'
+
+<a id="mosaic"></a>
+
+--8<-- 'devbook/reference/serialization/Mosaic.html'
+
+<a id="sizeprefixedmosaic"></a>
+
+--8<-- 'devbook/reference/serialization/SizePrefixedMosaic.html'
+
+<a id="mosaiclevy"></a>
+
+--8<-- 'devbook/reference/serialization/MosaicLevy.html'
+
+<a id="mosaicproperty"></a>
+
+--8<-- 'devbook/reference/serialization/MosaicProperty.html'
+
+<a id="sizeprefixedmosaicproperty"></a>
+
+--8<-- 'devbook/reference/serialization/SizePrefixedMosaicProperty.html'
+
+<a id="mosaicdefinition"></a>
+
+--8<-- 'devbook/reference/serialization/MosaicDefinition.html'
+
+<a id="mosaicdefinitiontransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/MosaicDefinitionTransactionV1.html'
+
+<a id="nonverifiablemosaicdefinitiontransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/NonVerifiableMosaicDefinitionTransactionV1.html'
+
+<a id="mosaicsupplychangetransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/MosaicSupplyChangeTransactionV1.html'
+
+<a id="nonverifiablemosaicsupplychangetransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/NonVerifiableMosaicSupplyChangeTransactionV1.html'
+
+<a id="multisigaccountmodification"></a>
+
+--8<-- 'devbook/reference/serialization/MultisigAccountModification.html'
+
+<a id="sizeprefixedmultisigaccountmodification"></a>
+
+--8<-- 'devbook/reference/serialization/SizePrefixedMultisigAccountModification.html'
+
+<a id="multisigaccountmodificationtransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/MultisigAccountModificationTransactionV1.html'
+
+<a id="nonverifiablemultisigaccountmodificationtransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/NonVerifiableMultisigAccountModificationTransactionV1.html'
+
+<a id="multisigaccountmodificationtransactionv2"></a>
+
+--8<-- 'devbook/reference/serialization/MultisigAccountModificationTransactionV2.html'
+
+<a id="nonverifiablemultisigaccountmodificationtransactionv2"></a>
+
+--8<-- 'devbook/reference/serialization/NonVerifiableMultisigAccountModificationTransactionV2.html'
+
+<a id="cosignaturev1body"></a>
+
+--8<-- 'devbook/reference/serialization/CosignatureV1Body.html'
+
+<a id="cosignaturev1"></a>
+
+--8<-- 'devbook/reference/serialization/CosignatureV1.html'
+
+<a id="nonverifiablecosignaturev1"></a>
+
+--8<-- 'devbook/reference/serialization/NonVerifiableCosignatureV1.html'
+
+<a id="sizeprefixedcosignaturev1"></a>
+
+--8<-- 'devbook/reference/serialization/SizePrefixedCosignatureV1.html'
+
+<a id="multisigtransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/MultisigTransactionV1.html'
+
+<a id="nonverifiablemultisigtransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/NonVerifiableMultisigTransactionV1.html'
+
+<a id="namespaceregistrationtransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/NamespaceRegistrationTransactionV1.html'
+
+<a id="nonverifiablenamespaceregistrationtransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/NonVerifiableNamespaceRegistrationTransactionV1.html'
+
+<a id="message"></a>
+
+--8<-- 'devbook/reference/serialization/Message.html'
+
+<a id="transfertransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/TransferTransactionV1.html'
+
+<a id="nonverifiabletransfertransactionv1"></a>
+
+--8<-- 'devbook/reference/serialization/NonVerifiableTransferTransactionV1.html'
+
+<a id="transfertransactionv2"></a>
+
+--8<-- 'devbook/reference/serialization/TransferTransactionV2.html'
+
+<a id="nonverifiabletransfertransactionv2"></a>
+
+--8<-- 'devbook/reference/serialization/NonVerifiableTransferTransactionV2.html'
+
+<a id="block"></a>
+
+--8<-- 'devbook/reference/serialization/Block.html'
+
 <style>
 .md-typeset h3 {
     background: var(--md-accent-fg-color--light);
@@ -58,6 +264,7 @@ hide:
 }
 
 .md-typeset table:not([class]) {
+    background: transparent;
     border: none;
 }
 .md-typeset table:not([class]) td {

--- a/mkdocs/snippets/devbook/reference/serialization/AccountKeyLinkTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/AccountKeyLinkTransactionV1.html
@@ -1,0 +1,106 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 173 bytes = 0xad</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/account_key_link/account_key_link.cats#L25">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:AccountKeyLinkTransactionV1</code></dt><dd>binary layout for an account key link transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">ACCOUNT_KEY_LINK</code> (<code class="docutils literal">0x801</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">link_action</code></div>
+   <div><a href="#linkaction" title="enumeration of link actions">LinkAction</a></div>
+   <div class="description"><p>link action </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">remote_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>remote account public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">remote_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>public key of remote account to which importance should be transferred </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/Block.html
+++ b/mkdocs/snippets/devbook/reference/serialization/Block.html
@@ -1,0 +1,100 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 168+ bytes = 0xa8+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/block.cats#L12">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:Block</code></dt><dd>binary layout for a block </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#blocktype" title="enumeration of block types">BlockType</a></div>
+   <div class="description"><p>block type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">previous_block_hash_outer_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">36</code><br/><p>previous block hash outer size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">previous_block_hash_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">previous_block_hash</code></div>
+   <div><a href="#hash256" title="">Hash256</a></div>
+   <div class="description"></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">height</code></div>
+   <div><a href="#height" title="">Height</a></div>
+   <div class="description"><p>block height </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">transactions_count</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>transactions count </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">transactions</code></div>
+   <div><a href="#transaction" title="binary layout for a transaction">Transaction</a>&ZeroWidthSpace;[transactions_count]</div>
+   <div class="description"><p>transactions </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/BlockType.html
+++ b/mkdocs/snippets/devbook/reference/serialization/BlockType.html
@@ -1,0 +1,16 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 4 bytes = 0x4</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/block.cats#L4">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:BlockType</code></dt><dd>enumeration of block types </dd></dl>
+</td></tr></table>
+
+<div class="big-table3">
+<div><b>0xffffffff</b></div>
+<div><code class="docutils literal">NEMESIS</code></div>
+<div class="description"><p>nemesis block </p></div>
+<div><b>0x1</b></div>
+<div><code class="docutils literal">NORMAL</code></div>
+<div class="description"><p>normal block </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/CosignatureV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/CosignatureV1.html
@@ -1,0 +1,118 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 217 bytes = 0xd9</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig.cats#L23">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:CosignatureV1</code></dt><dd>binary layout for a cosignature transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MULTISIG_COSIGNATURE</code> (<code class="docutils literal">0x1002</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">other_&ZeroWidthSpace;transaction_&ZeroWidthSpace;hash_&ZeroWidthSpace;outer_&ZeroWidthSpace;size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">36</code><br/><p>other transaction hash outer size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">other_transaction_hash_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>other transaction hash size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">other_transaction_hash</code></div>
+   <div><a href="#hash256" title="">Hash256</a></div>
+   <div class="description"><p>other transaction hash </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">multisig_account_address_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>multisig account address size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">multisig_account_address</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>multisig account address </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/CosignatureV1Body.html
+++ b/mkdocs/snippets/devbook/reference/serialization/CosignatureV1Body.html
@@ -1,0 +1,52 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 89 bytes = 0x59</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig.cats#L4">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:CosignatureV1Body</code></dt><dd>shared content between V1 verifiable and non-verifiable cosignature transactions </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MULTISIG_COSIGNATURE</code> (<code class="docutils literal">0x1002</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">other_&ZeroWidthSpace;transaction_&ZeroWidthSpace;hash_&ZeroWidthSpace;outer_&ZeroWidthSpace;size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">36</code><br/><p>other transaction hash outer size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">other_transaction_hash_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>other transaction hash size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">other_transaction_hash</code></div>
+   <div><a href="#hash256" title="">Hash256</a></div>
+   <div class="description"><p>other transaction hash </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">multisig_account_address_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>multisig account address size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">multisig_account_address</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>multisig account address </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/LinkAction.html
+++ b/mkdocs/snippets/devbook/reference/serialization/LinkAction.html
@@ -1,0 +1,16 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 4 bytes = 0x4</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/account_key_link/account_key_link.cats#L4">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:LinkAction</code></dt><dd>enumeration of link actions </dd></dl>
+</td></tr></table>
+
+<div class="big-table3">
+<div><b>0x1</b></div>
+<div><code class="docutils literal">LINK</code></div>
+<div class="description"><p>unlink account </p></div>
+<div><b>0x2</b></div>
+<div><code class="docutils literal">UNLINK</code></div>
+<div class="description"><p>link account </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/Message.html
+++ b/mkdocs/snippets/devbook/reference/serialization/Message.html
@@ -1,0 +1,28 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 8+ bytes = 0x8+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/transfer/transfer.cats#L14">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:Message</code></dt><dd>binary layout for a message </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">message_type</code></div>
+   <div><a href="#messagetype" title="enumeration of message types this is a hint used by the client but ignored by the server">MessageType</a></div>
+   <div class="description"><p>message type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">message_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>message size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">message</code></div>
+   <div>byte[message_size]</div>
+   <div class="description"><p>message payload </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MessageType.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MessageType.html
@@ -1,0 +1,16 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 4 bytes = 0x4</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/transfer/transfer.cats#L6">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MessageType</code></dt><dd>enumeration of message types this is a hint used by the client but ignored by the server </dd></dl>
+</td></tr></table>
+
+<div class="big-table3">
+<div><b>0x1</b></div>
+<div><code class="docutils literal">PLAIN</code></div>
+<div class="description"><p>plain message </p></div>
+<div><b>0x2</b></div>
+<div><code class="docutils literal">ENCRYPTED</code></div>
+<div class="description"><p>encrypted message </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/Mosaic.html
+++ b/mkdocs/snippets/devbook/reference/serialization/Mosaic.html
@@ -1,0 +1,28 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 20+ bytes = 0x14+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic.cats#L23">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:Mosaic</code></dt><dd>binary layout for a mosaic </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_id_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>mosaic id size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_id</code></div>
+   <div><a href="#mosaicid" title="binary layout for a mosaic id">MosaicId</a></div>
+   <div class="description"><p>mosaic id </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">amount</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>quantity </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MosaicDefinition.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MosaicDefinition.html
@@ -1,0 +1,70 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 60+ bytes = 0x3c+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic/mosaic_definition.cats#L55">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MosaicDefinition</code></dt><dd>binary layout for a mosaic definition </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">owner_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>owner public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">owner_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>owner public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">id_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>mosaic id size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">id</code></div>
+   <div><a href="#mosaicid" title="binary layout for a mosaic id">MosaicId</a></div>
+   <div class="description"><p>mosaic id referenced by this definition </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">description_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>description size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">description</code></div>
+   <div>byte[description_size]</div>
+   <div class="description"><p>description </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">properties_count</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>number of properties </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">properties</code></div>
+   <div><a href="#sizeprefixedmosaicproperty" title="binary layout for a size prefixed mosaic property">SizePrefixedMosaicProperty</a>&ZeroWidthSpace;[properties_count]</div>
+   <div class="description"><p>properties </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">levy_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>size of the serialized levy </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">levy</code></div>
+   <div><a href="#mosaiclevy" title="binary layout for a mosaic levy">MosaicLevy</a></div>
+   <div class="description"><p>optional levy that is applied to transfers of this mosaic </p><b>This field is only present if:</b><br/><code class="docutils literal">levy_size not equals 0</code></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MosaicDefinitionTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MosaicDefinitionTransactionV1.html
@@ -1,0 +1,118 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 249+ bytes = 0xf9+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic/mosaic_definition.cats#L105">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MosaicDefinitionTransactionV1</code></dt><dd>binary layout for a mosaic definition transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MOSAIC_DEFINITION</code> (<code class="docutils literal">0x4001</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_definition_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>mosaic definition size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_definition</code></div>
+   <div><a href="#mosaicdefinition" title="binary layout for a mosaic definition">MosaicDefinition</a></div>
+   <div class="description"><p>mosaic definition </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee_sink_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>mosaic rental fee sink public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee_sink</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>mosaic rental fee sink public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>mosaic rental fee </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MosaicId.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MosaicId.html
@@ -1,0 +1,28 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 8+ bytes = 0x8+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic.cats#L12">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MosaicId</code></dt><dd>binary layout for a mosaic id </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">namespace_id</code></div>
+   <div><a href="#namespaceid" title="binary layout for a namespace id">NamespaceId</a></div>
+   <div class="description"><p>namespace id </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">name_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>name size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">name</code></div>
+   <div>byte[name_size]</div>
+   <div class="description"><p>name </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MosaicLevy.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MosaicLevy.html
@@ -1,0 +1,46 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 68+ bytes = 0x44+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic/mosaic_definition.cats#L13">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MosaicLevy</code></dt><dd>binary layout for a mosaic levy </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">transfer_fee_type</code></div>
+   <div><a href="#mosaictransferfeetype" title="enumeration of mosaic transfer fee types">MosaicTransferFeeType</a></div>
+   <div class="description"><p>mosaic fee type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">recipient_address_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>recipient address size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">recipient_address</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>recipient address </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_id_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>levy mosaic id size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_id</code></div>
+   <div><a href="#mosaicid" title="binary layout for a mosaic id">MosaicId</a></div>
+   <div class="description"><p>levy mosaic id </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>amount of levy mosaic to transfer </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MosaicProperty.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MosaicProperty.html
@@ -1,0 +1,34 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 8+ bytes = 0x8+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic/mosaic_definition.cats#L34">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MosaicProperty</code></dt><dd>binary layout for a mosaic property supported property names are: divisibility, initialSupply, supplyMutable, transferable </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">name_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>property name size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">name</code></div>
+   <div>byte[name_size]</div>
+   <div class="description"><p>property name </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">value_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>property value size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">value</code></div>
+   <div>byte[value_size]</div>
+   <div class="description"><p>property value </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MosaicSupplyChangeAction.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MosaicSupplyChangeAction.html
@@ -1,0 +1,16 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 4 bytes = 0x4</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic/mosaic_supply_change.cats#L5">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MosaicSupplyChangeAction</code></dt><dd>enumeration of mosaic supply change actions </dd></dl>
+</td></tr></table>
+
+<div class="big-table3">
+<div><b>0x1</b></div>
+<div><code class="docutils literal">INCREASE</code></div>
+<div class="description"><p>increases the supply </p></div>
+<div><b>0x2</b></div>
+<div><code class="docutils literal">DECREASE</code></div>
+<div class="description"><p>decreases the supply </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MosaicSupplyChangeTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MosaicSupplyChangeTransactionV1.html
@@ -1,0 +1,112 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 157+ bytes = 0x9d+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic/mosaic_supply_change.cats#L30">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MosaicSupplyChangeTransactionV1</code></dt><dd>binary layout for a mosaic supply change transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MOSAIC_SUPPLY_CHANGE</code> (<code class="docutils literal">0x4002</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_id_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>mosaic id size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_id</code></div>
+   <div><a href="#mosaicid" title="binary layout for a mosaic id">MosaicId</a></div>
+   <div class="description"><p>mosaic id </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">action</code></div>
+   <div><a href="#mosaicsupplychangeaction" title="enumeration of mosaic supply change actions">MosaicSupplyChangeAction</a></div>
+   <div class="description"><p>supply change action </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">delta</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>change amount </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MosaicTransferFeeType.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MosaicTransferFeeType.html
@@ -1,0 +1,16 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 4 bytes = 0x4</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic/mosaic_definition.cats#L5">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MosaicTransferFeeType</code></dt><dd>enumeration of mosaic transfer fee types </dd></dl>
+</td></tr></table>
+
+<div class="big-table3">
+<div><b>0x1</b></div>
+<div><code class="docutils literal">ABSOLUTE</code></div>
+<div class="description"><p>fee represents an absolute value </p></div>
+<div><b>0x2</b></div>
+<div><code class="docutils literal">PERCENTILE</code></div>
+<div class="description"><p>fee is proportional to a percentile of the transferred mosaic </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MultisigAccountModification.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MultisigAccountModification.html
@@ -1,0 +1,28 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 40 bytes = 0x28</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig_account_modification.cats#L14">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MultisigAccountModification</code></dt><dd>binary layout for a multisig account modification </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">modification_type</code></div>
+   <div><a href="#multisigaccountmodificationtype" title="enumeration of multisig account modification types">MultisigAccountModificationType</a></div>
+   <div class="description"><p>modification type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">cosignatory_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>cosignatory public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">cosignatory_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>cosignatory public key </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MultisigAccountModificationTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MultisigAccountModificationTransactionV1.html
@@ -1,0 +1,100 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 137+ bytes = 0x89+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig_account_modification.cats#L62">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MultisigAccountModificationTransactionV1</code></dt><dd>binary layout for a multisig account modification transaction (V1) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MULTISIG_ACCOUNT_MODIFICATION</code> (<code class="docutils literal">0x1001</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">modifications_count</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>number of modifications </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">modifications</code></div>
+   <div><a href="#sizeprefixedmultisigaccountmodification" title="binary layout for a multisig account modification prefixed with size">SizePrefixedMultisigAccountModification</a>&ZeroWidthSpace;[modifications_count]</div>
+   <div class="description"><p>multisig account modifications </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MultisigAccountModificationTransactionV2.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MultisigAccountModificationTransactionV2.html
@@ -1,0 +1,112 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 145+ bytes = 0x91+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig_account_modification.cats#L72">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MultisigAccountModificationTransactionV2</code></dt><dd>binary layout for a multisig account modification transaction (V2, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">2</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MULTISIG_ACCOUNT_MODIFICATION</code> (<code class="docutils literal">0x1001</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">modifications_count</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>number of modifications </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">modifications</code></div>
+   <div><a href="#sizeprefixedmultisigaccountmodification" title="binary layout for a multisig account modification prefixed with size">SizePrefixedMultisigAccountModification</a>&ZeroWidthSpace;[modifications_count]</div>
+   <div class="description"><p>multisig account modifications </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">min_approval_delta_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">4</code><br/><p>the size of the min_approval_delta </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">min_approval_delta</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>relative change of the minimal number of cosignatories required when approving a transaction </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MultisigAccountModificationType.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MultisigAccountModificationType.html
@@ -1,0 +1,16 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 4 bytes = 0x4</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig_account_modification.cats#L4">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MultisigAccountModificationType</code></dt><dd>enumeration of multisig account modification types </dd></dl>
+</td></tr></table>
+
+<div class="big-table3">
+<div><b>0x1</b></div>
+<div><code class="docutils literal">ADD_COSIGNATORY</code></div>
+<div class="description"><p>add a new cosignatory </p></div>
+<div><b>0x2</b></div>
+<div><code class="docutils literal">DELETE_COSIGNATORY</code></div>
+<div class="description"><p>delete an existing cosignatory </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/MultisigTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/MultisigTransactionV1.html
@@ -1,0 +1,112 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 201+ bytes = 0xc9+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig.cats#L52">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:MultisigTransactionV1</code></dt><dd>binary layout for a multisig transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MULTISIG</code> (<code class="docutils literal">0x1004</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">inner_transaction_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>inner transaction size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">inner_transaction</code></div>
+   <div><a href="#nonverifiabletransaction" title="binary layout for a non-verifiable transaction">NonVerifiableTransaction</a></div>
+   <div class="description"><p>inner transaction </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">cosignatures_count</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>number of attached cosignatures </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">cosignatures</code></div>
+   <div><a href="#sizeprefixedcosignaturev1" title="cosignature attached to a multisig transaction with prefixed size">SizePrefixedCosignatureV1</a>&ZeroWidthSpace;[cosignatures_count]</div>
+   <div class="description"><p>cosignatures </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NamespaceId.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NamespaceId.html
@@ -1,0 +1,22 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 4+ bytes = 0x4+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic.cats#L4">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NamespaceId</code></dt><dd>binary layout for a namespace id </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">name_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>name size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">name</code></div>
+   <div>byte[name_size]</div>
+   <div class="description"><p>name </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NamespaceRegistrationTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NamespaceRegistrationTransactionV1.html
@@ -1,0 +1,130 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 193+ bytes = 0xc1+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/namespace/namespace_registration.cats#L28">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NamespaceRegistrationTransactionV1</code></dt><dd>binary layout for a namespace registration transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">NAMESPACE_REGISTRATION</code> (<code class="docutils literal">0x2001</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee_sink_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>mosaic rental fee sink public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee_sink</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>mosaic rental fee sink public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>mosaic rental fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">name_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>new namespace name size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">name</code></div>
+   <div>byte[name_size]</div>
+   <div class="description"><p>new namespace name </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">parent_name_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>size of the parent namespace name </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">parent_name</code></div>
+   <div>byte[parent_name_size]</div>
+   <div class="description"><p>parent namespace name </p><b>This field is only present if:</b><br/><code class="docutils literal">parent_name_size not equals 4294967295</code></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NetworkType.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NetworkType.html
@@ -1,0 +1,16 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 1 byte = 0x1</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/entity.cats#L4">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NetworkType</code></dt><dd>enumeration of network types </dd></dl>
+</td></tr></table>
+
+<div class="big-table3">
+<div><b>0x68</b></div>
+<div><code class="docutils literal">MAINNET</code></div>
+<div class="description"><p>main network </p></div>
+<div><b>0x98</b></div>
+<div><code class="docutils literal">TESTNET</code></div>
+<div class="description"><p>test network </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NonVerifiableAccountKeyLinkTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NonVerifiableAccountKeyLinkTransactionV1.html
@@ -1,0 +1,94 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 105 bytes = 0x69</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/account_key_link/account_key_link.cats#L30">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NonVerifiableAccountKeyLinkTransactionV1</code></dt><dd>binary layout for a non-verifiable account key link transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">ACCOUNT_KEY_LINK</code> (<code class="docutils literal">0x801</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">link_action</code></div>
+   <div><a href="#linkaction" title="enumeration of link actions">LinkAction</a></div>
+   <div class="description"><p>link action </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">remote_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>remote account public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">remote_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>public key of remote account to which importance should be transferred </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NonVerifiableCosignatureV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NonVerifiableCosignatureV1.html
@@ -1,0 +1,106 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 149 bytes = 0x95</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig.cats#L28">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NonVerifiableCosignatureV1</code></dt><dd>binary layout for a non-verifiable cosignature transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MULTISIG_COSIGNATURE</code> (<code class="docutils literal">0x1002</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">other_&ZeroWidthSpace;transaction_&ZeroWidthSpace;hash_&ZeroWidthSpace;outer_&ZeroWidthSpace;size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">36</code><br/><p>other transaction hash outer size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">other_transaction_hash_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>other transaction hash size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">other_transaction_hash</code></div>
+   <div><a href="#hash256" title="">Hash256</a></div>
+   <div class="description"><p>other transaction hash </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">multisig_account_address_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>multisig account address size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">multisig_account_address</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>multisig account address </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NonVerifiableMosaicDefinitionTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NonVerifiableMosaicDefinitionTransactionV1.html
@@ -1,0 +1,106 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 181+ bytes = 0xb5+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic/mosaic_definition.cats#L110">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NonVerifiableMosaicDefinitionTransactionV1</code></dt><dd>binary layout for a non-verifiable mosaic definition transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MOSAIC_DEFINITION</code> (<code class="docutils literal">0x4001</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_definition_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>mosaic definition size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_definition</code></div>
+   <div><a href="#mosaicdefinition" title="binary layout for a mosaic definition">MosaicDefinition</a></div>
+   <div class="description"><p>mosaic definition </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee_sink_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>mosaic rental fee sink public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee_sink</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>mosaic rental fee sink public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>mosaic rental fee </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NonVerifiableMosaicSupplyChangeTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NonVerifiableMosaicSupplyChangeTransactionV1.html
@@ -1,0 +1,100 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 89+ bytes = 0x59+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic/mosaic_supply_change.cats#L35">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NonVerifiableMosaicSupplyChangeTransactionV1</code></dt><dd>binary layout for a non-verifiable mosaic supply change transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MOSAIC_SUPPLY_CHANGE</code> (<code class="docutils literal">0x4002</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_id_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>mosaic id size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_id</code></div>
+   <div><a href="#mosaicid" title="binary layout for a mosaic id">MosaicId</a></div>
+   <div class="description"><p>mosaic id </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">action</code></div>
+   <div><a href="#mosaicsupplychangeaction" title="enumeration of mosaic supply change actions">MosaicSupplyChangeAction</a></div>
+   <div class="description"><p>supply change action </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">delta</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>change amount </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NonVerifiableMultisigAccountModificationTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NonVerifiableMultisigAccountModificationTransactionV1.html
@@ -1,0 +1,88 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 69+ bytes = 0x45+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig_account_modification.cats#L67">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NonVerifiableMultisigAccountModificationTransactionV1</code></dt><dd>binary layout for a non-verifiable multisig account modification transaction (V1) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MULTISIG_ACCOUNT_MODIFICATION</code> (<code class="docutils literal">0x1001</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">modifications_count</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>number of modifications </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">modifications</code></div>
+   <div><a href="#sizeprefixedmultisigaccountmodification" title="binary layout for a multisig account modification prefixed with size">SizePrefixedMultisigAccountModification</a>&ZeroWidthSpace;[modifications_count]</div>
+   <div class="description"><p>multisig account modifications </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NonVerifiableMultisigAccountModificationTransactionV2.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NonVerifiableMultisigAccountModificationTransactionV2.html
@@ -1,0 +1,100 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 77+ bytes = 0x4d+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig_account_modification.cats#L77">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NonVerifiableMultisigAccountModificationTransactionV2</code></dt><dd>binary layout for a non-verifiable multisig account modification transaction (V2, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">2</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MULTISIG_ACCOUNT_MODIFICATION</code> (<code class="docutils literal">0x1001</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">modifications_count</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>number of modifications </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">modifications</code></div>
+   <div><a href="#sizeprefixedmultisigaccountmodification" title="binary layout for a multisig account modification prefixed with size">SizePrefixedMultisigAccountModification</a>&ZeroWidthSpace;[modifications_count]</div>
+   <div class="description"><p>multisig account modifications </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">min_approval_delta_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">4</code><br/><p>the size of the min_approval_delta </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">min_approval_delta</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>relative change of the minimal number of cosignatories required when approving a transaction </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NonVerifiableMultisigTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NonVerifiableMultisigTransactionV1.html
@@ -1,0 +1,88 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 129 bytes = 0x81</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig.cats#L63">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NonVerifiableMultisigTransactionV1</code></dt><dd>binary layout for a non-verifiable multisig transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">MULTISIG</code> (<code class="docutils literal">0x1004</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">inner_transaction_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>inner transaction size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">inner_transaction</code></div>
+   <div><a href="#nonverifiabletransaction" title="binary layout for a non-verifiable transaction">NonVerifiableTransaction</a></div>
+   <div class="description"><p>inner transaction </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NonVerifiableNamespaceRegistrationTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NonVerifiableNamespaceRegistrationTransactionV1.html
@@ -1,0 +1,118 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 125+ bytes = 0x7d+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/namespace/namespace_registration.cats#L33">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NonVerifiableNamespaceRegistrationTransactionV1</code></dt><dd>binary layout for a non-verifiable namespace registration transaction (V1, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">NAMESPACE_REGISTRATION</code> (<code class="docutils literal">0x2001</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee_sink_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>mosaic rental fee sink public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee_sink</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>mosaic rental fee sink public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">rental_fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>mosaic rental fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">name_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>new namespace name size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">name</code></div>
+   <div>byte[name_size]</div>
+   <div class="description"><p>new namespace name </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">parent_name_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>size of the parent namespace name </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">parent_name</code></div>
+   <div>byte[parent_name_size]</div>
+   <div class="description"><p>parent namespace name </p><b>This field is only present if:</b><br/><code class="docutils literal">parent_name_size not equals 4294967295</code></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NonVerifiableTransaction.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NonVerifiableTransaction.html
@@ -1,0 +1,63 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 60 bytes = 0x3c</td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NonVerifiableTransaction</code></dt><dd>binary layout for a non-verifiable transaction </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NonVerifiableTransferTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NonVerifiableTransferTransactionV1.html
@@ -1,0 +1,106 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 121+ bytes = 0x79+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/transfer/transfer.cats#L68">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NonVerifiableTransferTransactionV1</code></dt><dd>binary layout for a non-verifiable transfer transaction (V1) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">TRANSFER</code> (<code class="docutils literal">0x101</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">recipient_address_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>recipient address size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">recipient_address</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>recipient address </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">amount</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>XEM amount </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">message_envelope_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>message envelope size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">message</code></div>
+   <div><a href="#message" title="binary layout for a message">Message</a></div>
+   <div class="description"><p>optional message </p><b>This field is only present if:</b><br/><code class="docutils literal">message_envelope_size not equals 0</code></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/NonVerifiableTransferTransactionV2.html
+++ b/mkdocs/snippets/devbook/reference/serialization/NonVerifiableTransferTransactionV2.html
@@ -1,0 +1,118 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 125+ bytes = 0x7d+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/transfer/transfer.cats#L78">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:NonVerifiableTransferTransactionV2</code></dt><dd>binary layout for a non-verifiable transfer transaction (V2, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">2</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">TRANSFER</code> (<code class="docutils literal">0x101</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">recipient_address_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>recipient address size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">recipient_address</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>recipient address </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">amount</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>XEM amount </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">message_envelope_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>message envelope size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">message</code></div>
+   <div><a href="#message" title="binary layout for a message">Message</a></div>
+   <div class="description"><p>optional message </p><b>This field is only present if:</b><br/><code class="docutils literal">message_envelope_size not equals 0</code></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaics_count</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>number of attached mosaics </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaics</code></div>
+   <div><a href="#sizeprefixedmosaic" title="binary layout for a mosaic with a size prefixed size">SizePrefixedMosaic</a>&ZeroWidthSpace;[mosaics_count]</div>
+   <div class="description"><p>attached mosaics notice that mosaic amount is multipled by transfer amount to get effective amount </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/SizePrefixedCosignatureV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/SizePrefixedCosignatureV1.html
@@ -1,0 +1,22 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 221 bytes = 0xdd</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig.cats#L33">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:SizePrefixedCosignatureV1</code></dt><dd>cosignature attached to a multisig transaction with prefixed size </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">cosignature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>cosignature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">cosignature</code></div>
+   <div><a href="#cosignaturev1" title="binary layout for a cosignature transaction (V1, latest)">CosignatureV1</a></div>
+   <div class="description"><p>cosignature </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/SizePrefixedMosaic.html
+++ b/mkdocs/snippets/devbook/reference/serialization/SizePrefixedMosaic.html
@@ -1,0 +1,22 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 24+ bytes = 0x18+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic.cats#L34">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:SizePrefixedMosaic</code></dt><dd>binary layout for a mosaic with a size prefixed size </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>mosaic size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaic</code></div>
+   <div><a href="#mosaic" title="binary layout for a mosaic">Mosaic</a></div>
+   <div class="description"><p>mosaic </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/SizePrefixedMosaicProperty.html
+++ b/mkdocs/snippets/devbook/reference/serialization/SizePrefixedMosaicProperty.html
@@ -1,0 +1,22 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 12+ bytes = 0xc+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/mosaic/mosaic_definition.cats#L46">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:SizePrefixedMosaicProperty</code></dt><dd>binary layout for a size prefixed mosaic property </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">property_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>property size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">property</code></div>
+   <div><a href="#mosaicproperty" title="binary layout for a mosaic property supported property names are: divisibility, initialSupply, supplyMutable, transferable">MosaicProperty</a></div>
+   <div class="description"><p>property value </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/SizePrefixedMultisigAccountModification.html
+++ b/mkdocs/snippets/devbook/reference/serialization/SizePrefixedMultisigAccountModification.html
@@ -1,0 +1,22 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 44 bytes = 0x2c</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/multisig/multisig_account_modification.cats#L25">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:SizePrefixedMultisigAccountModification</code></dt><dd>binary layout for a multisig account modification prefixed with size </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">modification_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>modification size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">modification</code></div>
+   <div><a href="#multisigaccountmodification" title="binary layout for a multisig account modification">MultisigAccountModification</a></div>
+   <div class="description"><p>modification </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/Transaction.html
+++ b/mkdocs/snippets/devbook/reference/serialization/Transaction.html
@@ -1,0 +1,75 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 128 bytes = 0x80</td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:Transaction</code></dt><dd>binary layout for a transaction </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/TransactionType.html
+++ b/mkdocs/snippets/devbook/reference/serialization/TransactionType.html
@@ -1,0 +1,34 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 4 bytes = 0x4</td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/transaction_type.cats#L2">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:TransactionType</code></dt><dd>enumeration of transaction types </dd></dl>
+</td></tr></table>
+
+<div class="big-table3">
+<div><b>0x101</b></div>
+<div><code class="docutils literal">TRANSFER</code></div>
+<div class="description"><p>transfer transaction </p></div>
+<div><b>0x801</b></div>
+<div><code class="docutils literal">ACCOUNT_KEY_LINK</code></div>
+<div class="description"><p>account key link trasaction alternatively called importance transfer transaction </p></div>
+<div><b>0x1001</b></div>
+<div><code class="docutils literal">MULTISIG_ACCOUNT_MODIFICATION</code></div>
+<div class="description"><p>multisig account modification transaction alternatively called multisig consignatory modification transaction </p></div>
+<div><b>0x1002</b></div>
+<div><code class="docutils literal">MULTISIG_COSIGNATURE</code></div>
+<div class="description"><p>multisig cosignature transaction alternatively called multisig signature transaction </p></div>
+<div><b>0x1004</b></div>
+<div><code class="docutils literal">MULTISIG</code></div>
+<div class="description"><p>multisig transaction </p></div>
+<div><b>0x2001</b></div>
+<div><code class="docutils literal">NAMESPACE_REGISTRATION</code></div>
+<div class="description"><p>namespace registration transaction alternatively called provision namespace transaction </p></div>
+<div><b>0x4001</b></div>
+<div><code class="docutils literal">MOSAIC_DEFINITION</code></div>
+<div class="description"><p>mosaic definition transaction alternatively called mosaic definition creation transaction </p></div>
+<div><b>0x4002</b></div>
+<div><code class="docutils literal">MOSAIC_SUPPLY_CHANGE</code></div>
+<div class="description"><p>mosaic supply change transaction </p></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/TransferTransactionV1.html
+++ b/mkdocs/snippets/devbook/reference/serialization/TransferTransactionV1.html
@@ -1,0 +1,118 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 189+ bytes = 0xbd+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/transfer/transfer.cats#L63">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:TransferTransactionV1</code></dt><dd>binary layout for a transfer transaction (V1) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">1</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">TRANSFER</code> (<code class="docutils literal">0x101</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">recipient_address_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>recipient address size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">recipient_address</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>recipient address </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">amount</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>XEM amount </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">message_envelope_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>message envelope size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">message</code></div>
+   <div><a href="#message" title="binary layout for a message">Message</a></div>
+   <div class="description"><p>optional message </p><b>This field is only present if:</b><br/><code class="docutils literal">message_envelope_size not equals 0</code></div>
+</div>

--- a/mkdocs/snippets/devbook/reference/serialization/TransferTransactionV2.html
+++ b/mkdocs/snippets/devbook/reference/serialization/TransferTransactionV2.html
@@ -1,0 +1,130 @@
+<table style="width: 100%;"><tr><td>
+    <div class="side-info"><table>
+    <tr><td class="side-info-icon">&varr;</td><td>Size: 193+ bytes = 0xc1+ <i>(variable)</i></td></tr>
+    <tr><td class="side-info-icon"><i class="fab fa-github"></i></td><td><a href="https://github.com/symbol/symbol/blob/main/catbuffer/schemas/nem/transfer/transfer.cats#L73">schema</a></td></tr>
+    </table></div>
+    <dl markdown><dt><code>ser:TransferTransactionV2</code></dt><dd>binary layout for a transfer transaction (V2, latest) </dd></dl>
+</td></tr></table>
+
+<div class="big-table6">
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">type</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><p>transaction type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">version</code></div>
+   <div>byte[1]</div>
+   <div class="description"><p>entity version </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">entity_body_reserved_1</code></div>
+   <div>byte[2]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">0</code><br/><p>reserved padding between version and network type </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">network</code></div>
+   <div><a href="#networktype" title="enumeration of network types">NetworkType</a></div>
+   <div class="description"><p>entity network </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">timestamp</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>entity timestamp </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">32</code><br/><p>entity signer public key size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signer_public_key</code></div>
+   <div><a href="#publickey" title="">PublicKey</a></div>
+   <div class="description"><p>entity signer public key </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">64</code><br/><p>entity signature size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">signature</code></div>
+   <div><a href="#signature" title="">Signature</a></div>
+   <div class="description"><p>entity signature </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">fee</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>transaction fee </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">deadline</code></div>
+   <div><a href="#timestamp" title="">Timestamp</a></div>
+   <div class="description"><p>transaction deadline </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_VERSION</code></div>
+   <div>byte[1]</div>
+   <div class="description"><b>const</b> <code class="docutils literal">2</code><br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">TRANSACTION_TYPE</code></div>
+   <div><a href="#transactiontype" title="enumeration of transaction types">TransactionType</a></div>
+   <div class="description"><b>const</b> <code class="docutils literal">TRANSFER</code> (<code class="docutils literal">0x101</code>)<br/></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">recipient_address_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><b>reserved</b> <code class="docutils literal">40</code><br/><p>recipient address size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">recipient_address</code></div>
+   <div><a href="#address" title="">Address</a></div>
+   <div class="description"><p>recipient address </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">amount</code></div>
+   <div><a href="#amount" title="">Amount</a></div>
+   <div class="description"><p>XEM amount </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">message_envelope_size</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>message envelope size </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">message</code></div>
+   <div><a href="#message" title="binary layout for a message">Message</a></div>
+   <div class="description"><p>optional message </p><b>This field is only present if:</b><br/><code class="docutils literal">message_envelope_size not equals 0</code></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaics_count</code></div>
+   <div>byte[4]</div>
+   <div class="description"><p>number of attached mosaics </p></div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div>&nbsp;</div>
+   <div><code class="docutils literal">mosaics</code></div>
+   <div><a href="#sizeprefixedmosaic" title="binary layout for a mosaic with a size prefixed size">SizePrefixedMosaic</a>&ZeroWidthSpace;[mosaics_count]</div>
+   <div class="description"><p>attached mosaics notice that mosaic amount is multipled by transfer amount to get effective amount </p></div>
+</div>


### PR DESCRIPTION
Adds serialization docs generated with [catapult-docs-cli](https://github.com/symbol/symbol-docs/blob/main/catapult-docs-cli/README.md#generate-serialization-docs-for-nem).

Other related PRs to review:

- https://github.com/symbol/symbol-docs/pull/1168
- https://github.com/symbol/symbol/pull/2004