### PR TITLE
[mkdocs] docs: add transfer xem tutorial

### DIFF
--- a/mkdocs/config/mkdocs.en.yml
+++ b/mkdocs/config/mkdocs.en.yml
@@ -86,6 +86,8 @@ nav:
               - devbook/accounts/create-from-mnemonic.md
               - devbook/accounts/testnet-faucet.md
               - devbook/accounts/query-balance.md
+      - Transactions:
+          - devbook/transactions/transfer-xem.md
       - Reference Guides:
           - Python SDK: devbook/reference/py/
           - TypeScript SDK: devbook/reference/ts/

--- a/mkdocs/pages/en/devbook/transactions/transfer-xem.md
+++ b/mkdocs/pages/en/devbook/transactions/transfer-xem.md
@@ -99,7 +99,7 @@ This provides a good balance between accuracy and performance.
 
 {{ tutorial.code_snippet_tagged('step-4') }}
 
-Every transaction pays a fee to the <harvester:> that includes it in a block.
+Every transaction pays a fee to the <harvester account:> that includes it in a block.
 
 NEM uses a fixed fee schedule, so the snippet calculates the fee locally without contacting a node.
 For a XEM-only transfer, the fee starts at 0.05 XEM for small amounts and grows with the XEM sent, up to a cap of
@@ -137,7 +137,7 @@ the transfer transaction:
 
 !!! info "Sending a mosaic or a message"
 
-    A <ser:TransferTransactionV2> can also carry other <mosaics:> instead of XEM, or include a <message:>, with the fee
+    A <ser:TransferTransactionV2> can also carry other <mosaics:> instead of XEM, or include a message, with the fee
     calculated differently in each case.
     See the [Transfer Mosaics](./transfer-mosaics.md) and [Transfer with a Message](./messages.md) tutorials.
 

--- a/mkdocs/pages/en/devbook/transactions/transfer-xem.md
+++ b/mkdocs/pages/en/devbook/transactions/transfer-xem.md
@@ -1,0 +1,229 @@
+---
+title: Transfer XEM
+tutorial_level: beginner
+---
+
+# Sending XEM with a Transfer Transaction
+
+Sending <XEM:> from one <account:> to another is the most basic action on the NEM blockchain, and every other type of
+<transaction:> follows the same general pattern.
+
+```dot
+digraph "Transfer XEM" {
+    rankdir="LR";
+    node [fontsize=12];
+
+    A [label="A"];
+    B [label="B"];
+
+    A -> B [label="1 XEM"];
+}
+```
+
+This tutorial shows how to create, sign, and announce a <transfer transaction:> that sends 1 XEM between two accounts,
+and then poll the transaction's status until it is confirmed.
+
+## Prerequisites
+
+Before you start, make sure to:
+
+* Set up your development environment.
+    See [Setting Up a Development Environment](../start/setup.md).
+* Create an <account:> to send the transfer transaction, either
+    [from code](../accounts/create-from-private-key.md) or
+    [by using a wallet](../../userbook/wallet/create-account.md).
+* Obtain <XEM:> to pay for the transaction fee and transfer amount.
+    See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
+
+## Full Code
+
+{% import 'tutorial.jinja2' as tutorial with context %}
+
+{{ tutorial.code_full_tagged('devbook/transactions/transfer_xem', ['py', 'js']) }}
+
+The whole code is wrapped in a single `try` block to provide simple error handling,
+but applications will probably want to use more fine-grained control.
+
+## Code Explanation
+
+### Setting Up the Accounts
+
+{{ tutorial.code_snippet_tagged('step-1') }}
+
+Every transfer transaction involves two accounts: a **sender** and a **recipient**.
+
+The **sender** is the <account:> that signs the transaction and pays the fee.
+Its private key is loaded from the `SIGNER_PRIVATE_KEY` environment variable.
+If not provided, a test key is used as default.
+
+The **recipient** is the account that receives the XEM.
+Its testnet <address:>, which is all that is needed to send funds, is loaded from the `RECIPIENT_ADDRESS`
+environment variable.
+If not provided, a test address is used as default.
+
+### Defining the Transfer Amount
+
+{{ tutorial.code_snippet_tagged('step-2') }}
+
+The snippet defines the transfer amount in the `xem` variable, loaded from the `XEM_AMOUNT` environment variable.
+If not provided, a default of 1 XEM is used.
+
+The transaction's `amount` field requires atomic units, not whole XEM.
+<XEM:> has a <divisibility:> of 6, so one XEM equals one million atomic units.
+The snippet derives `amount` by multiplying `xem` by 1'000'000.
+
+### Fetching Network Time
+
+{{ tutorial.code_snippet_tagged('step-3') }}
+
+Every NEM transaction contains two time fields, both expressed in <network time:>,
+the number of seconds since the NEM nemesis block:
+
+* `timestamp`: The moment the transaction is created, set here to the current network time.
+* `deadline`: How long the network keeps trying to confirm the transaction before discarding it.
+    It must be after the timestamp and no more than 24 hours later.
+    Otherwise, the node rejects the transaction.
+    This example sets it two hours after the timestamp, well within the limit.
+
+Building a transfer therefore needs an accurate network time.
+
+The <get:/time-sync/network-time> endpoint reports the node's current network time.
+The node returns this value in milliseconds, so the code divides it by 1000 to obtain the seconds that transactions
+expect.
+
+However, applications do not need to query the network time before every transaction.
+It can be fetched once and then adjusted using the local system clock when needed.
+This provides a good balance between accuracy and performance.
+
+### Calculating the Transaction Fee
+
+{{ tutorial.code_snippet_tagged('step-4') }}
+
+Every transaction pays a fee that rewards the nodes that process it and include it in a block.
+
+NEM fees are not market-driven.
+Instead of floating with network demand, NEM uses a fixed, published schedule, so the fee can be calculated in
+advance without contacting a node.
+
+For an XEM transfer, the fee depends only on the amount being sent:
+
+* A transfer of up to 10,000 XEM costs 0.05 XEM.
+* Above that, the fee rises by 0.05 XEM for every further 10,000 XEM sent.
+* The fee is capped at 1.25 XEM, however large the transfer.
+
+The snippet derives the fee from `xem`, defined in the previous step:
+
+* `fee_steps` is the number of full 10'000-XEM increments in `xem`, clamped between 1 and 25.
+* `fee` is `fee_steps` multiplied by 50'000 atomic units, the value of one increment (0.05 XEM).
+
+With the default 1 XEM, the fee falls in the first increment (0.05 XEM).
+
+Attaching a message or sending other <mosaics:> costs more than this XEM-only fee.
+
+### Building the Transaction
+
+{{ tutorial.code_snippet_tagged('step-5') }}
+
+The snippet calls <dy:TransactionFactory.create> with a descriptor that supplies every required property of
+the transfer transaction:
+
+* `type`: This tutorial uses `transfer_transaction_v2`, the current transfer version, which can
+    carry both XEM and other <mosaics:>.
+    No mosaics are attached here, so the transaction sends XEM only.
+
+* `signer_public_key`: The signer is the account that will pay the fee.
+    In a transfer transaction, it is also the source of the transferred XEM and mosaics.
+
+* `fee`: The value calculated in the previous step. For 1 XEM, this is `50_000` atomic units (0.05 XEM).
+
+* `timestamp` and `deadline`: The values computed in the network time step.
+
+* `recipient_address`: The address that will receive the XEM.
+
+* `amount`: The atomic-unit value computed earlier. For 1 XEM, this is `1_000_000`.
+
+!!! info "Sending a mosaic or a message"
+
+    A <ser:TransferTransactionV2> can also carry other <mosaics:> instead of XEM, or include a
+    <message:>, with the fee calculated differently in each case.
+    See the [Transfer Mosaics](./transfer-mosaics.md) and [Transfer with a Message](./messages.md) tutorials.
+
+### Signing and Serializing
+
+{{ tutorial.code_snippet_tagged('step-6') }}
+
+Once the transaction is created, it must be signed with the signing account's private key.
+Signing ensures the transaction is authentic and authorized by the sender.
+
+<dy:NemFacade.signTransaction> returns a <signature:> encoded as a hexadecimal string.
+
+<dy:TransactionFactory.attachSignature> adds the signature to the transaction and serializes it into a JSON payload
+ready to be submitted directly to a node for announcement.
+
+### Announcing the Transaction
+
+{{ tutorial.code_snippet_tagged('step-7') }}
+
+The signed payload is submitted to the <post:/transaction/announce> endpoint of any NEM <node:>.
+
+The node validates the transaction as soon as it is announced and reports the outcome in the response.
+A result of `SUCCESS` means the transaction passed this first check and was added to the <unconfirmed pool:>.
+Any other result means the node did not accept it, and the response message explains why, for example that the
+account does not hold enough XEM to cover the amount and the fee.
+
+!!! warning "Do not rely on unconfirmed transactions"
+
+    A `SUCCESS` result only means the transaction reached the unconfirmed pool.
+    It is not yet guaranteed to be included in a block.
+    Wait until it is [confirmed](#waiting-for-confirmation), and ideally past the <rewrite limit:>, before relying
+    on it.
+
+### Waiting for Confirmation
+
+{{ tutorial.code_snippet_tagged('step-8') }}
+
+The snippet above repeatedly queries the <get:/transaction/get> endpoint using the hash of the announced transaction.
+
+!!! note "Polling vs WebSockets"
+
+    This step uses polling to check whether the transaction has been confirmed.
+    Polling is used here for illustration purposes, but it is not the recommended approach for real applications.
+
+    [WebSockets](../websockets/listen-transaction-flow.md) provide a more responsive solution without the overhead of
+    repeated API calls.
+
+While the transaction is still unconfirmed, the endpoint responds with an error, and the code waits one second
+before retrying, for up to 120 attempts (about two minutes).
+
+Once the transaction is included in a block, the endpoint returns it together with the block height, and the loop
+ends.
+
+NEM produces a block roughly once per minute, so confirmation usually takes from a few seconds to a couple of minutes.
+
+## Output
+
+The output shown below corresponds to a typical run of the program.
+
+```text
+--8<-- 'devbook/transactions/transfer_xem.log'
+```
+
+The number of `pending` checks depends on how soon the next block is harvested, so it varies between runs.
+
+To see the transaction from the network's perspective, you can search for the transaction hash on a [NEM testnet
+explorer](https://testnet.nem.fyi/).
+The hash is printed in the line that says `Waiting for confirmation from /transaction/get?hash=...`.
+
+## Conclusion
+
+This tutorial showed how to:
+
+| Step                                                        | Related documentation                                                                                               |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------|
+| [Obtain the network time](#fetching-network-time)           | <get:/time-sync/network-time>                                                                                       |
+| [Build the transaction](#building-the-transaction)          | <dy:TransactionFactory.create>                                                                                      |
+| [Sign the transaction](#signing-and-serializing)            | <dy:NemFacade.signTransaction><br/><dy:TransactionFactory.attachSignature>                                          |
+| [Announce the transaction](#announcing-the-transaction)     | <post:/transaction/announce>                                                                                        |
+| [Wait for confirmation](#waiting-for-confirmation)          | <get:/transaction/get>                                                                                              |
+
+Most other NEM transaction types are created, signed, and announced in the same way.

--- a/mkdocs/pages/en/devbook/transactions/transfer-xem.md
+++ b/mkdocs/pages/en/devbook/transactions/transfer-xem.md
@@ -57,19 +57,19 @@ Its private key is loaded from the `SIGNER_PRIVATE_KEY` environment variable.
 If not provided, a test key is used as default.
 
 The **recipient** is the account that receives the XEM.
-Its testnet <address:>, which is all that is needed to send funds, is loaded from the `RECIPIENT_ADDRESS`
-environment variable.
+Its <address:> is loaded from the `RECIPIENT_ADDRESS` environment variable.
 If not provided, a test address is used as default.
 
 ### Defining the Transfer Amount
 
 {{ tutorial.code_snippet_tagged('step-2') }}
 
-The snippet defines the transfer amount in the `xem` variable, loaded from the `XEM_AMOUNT` environment variable.
+The snippet defines the transfer amount in the `xem` variable, loaded as a number from the `XEM_AMOUNT`
+environment variable.
 If not provided, a default of 1 XEM is used.
 
 The transaction's `amount` field requires atomic units, not whole XEM.
-<XEM:> has a <divisibility:> of 6, so one XEM equals one million atomic units.
+XEM has a <divisibility:> of 6, so one XEM equals one million atomic units.
 The snippet derives `amount` by multiplying `xem` by 1'000'000.
 
 ### Fetching Network Time
@@ -99,26 +99,19 @@ This provides a good balance between accuracy and performance.
 
 {{ tutorial.code_snippet_tagged('step-4') }}
 
-Every transaction pays a fee that rewards the nodes that process it and include it in a block.
+Every transaction pays a fee to the <harvester:> that includes it in a block.
 
-NEM fees are not market-driven.
-Instead of floating with network demand, NEM uses a fixed, published schedule, so the fee can be calculated in
-advance without contacting a node.
+NEM uses a fixed fee schedule, so the snippet calculates the fee locally without contacting a node.
+For a XEM-only transfer, the fee starts at 0.05 XEM for small amounts and grows with the XEM sent, up to a cap of
+1.25 XEM.
+See [Fees](../../textbook/transfer_transactions.md#fees) for the full rules, including the mosaic and message costs.
 
-For an XEM transfer, the fee depends only on the amount being sent:
-
-* A transfer of up to 10,000 XEM costs 0.05 XEM.
-* Above that, the fee rises by 0.05 XEM for every further 10,000 XEM sent.
-* The fee is capped at 1.25 XEM, however large the transfer.
-
-The snippet derives the fee from `xem`, defined in the previous step:
+The snippet implements this schedule:
 
 * `fee_steps` is the number of full 10'000-XEM increments in `xem`, clamped between 1 and 25.
 * `fee` is `fee_steps` multiplied by 50'000 atomic units, the value of one increment (0.05 XEM).
 
 With the default 1 XEM, the fee falls in the first increment (0.05 XEM).
-
-Attaching a message or sending other <mosaics:> costs more than this XEM-only fee.
 
 ### Building the Transaction
 
@@ -127,8 +120,8 @@ Attaching a message or sending other <mosaics:> costs more than this XEM-only fe
 The snippet calls <dy:TransactionFactory.create> with a descriptor that supplies every required property of
 the transfer transaction:
 
-* `type`: This tutorial uses `transfer_transaction_v2`, the current transfer version, which can
-    carry both XEM and other <mosaics:>.
+* `type`: This tutorial uses <ser:TransferTransactionV2>, the current transfer version, which can carry both XEM and
+    other <mosaics:>.
     No mosaics are attached here, so the transaction sends XEM only.
 
 * `signer_public_key`: The signer is the account that will pay the fee.
@@ -144,8 +137,8 @@ the transfer transaction:
 
 !!! info "Sending a mosaic or a message"
 
-    A <ser:TransferTransactionV2> can also carry other <mosaics:> instead of XEM, or include a
-    <message:>, with the fee calculated differently in each case.
+    A <ser:TransferTransactionV2> can also carry other <mosaics:> instead of XEM, or include a <message:>, with the fee
+    calculated differently in each case.
     See the [Transfer Mosaics](./transfer-mosaics.md) and [Transfer with a Message](./messages.md) tutorials.
 
 ### Signing and Serializing

--- a/mkdocs/pages/en/devbook/transactions/transfer-xem.md
+++ b/mkdocs/pages/en/devbook/transactions/transfer-xem.md
@@ -132,7 +132,7 @@ the transfer transaction:
     No mosaics are attached here, so the transaction sends XEM only.
 
 * `signer_public_key`: The signer is the account that will pay the fee.
-    In a transfer transaction, it is also the source of the transferred XEM and mosaics.
+    In a transfer transaction, it is also the source of the transferred XEM.
 
 * `fee`: The value calculated in the previous step. For 1 XEM, this is `50_000` atomic units (0.05 XEM).
 

--- a/mkdocs/pages/en/textbook/transactions.md
+++ b/mkdocs/pages/en/textbook/transactions.md
@@ -275,3 +275,40 @@ and validation steps, but differ in purpose and required fields.
 | `Mosaic Supply Change`                                              | Change the total supply of a mosaic.                                                                          |
 
 </div>
+
+## Transaction Fees
+
+Every transaction pays a fee that compensates the <harvester account:> that includes it in a block.
+
+NEM fees are not market-driven.
+The network publishes a fixed schedule, so the cost of any transaction can be calculated up front without contacting a
+node.
+
+### Fee Schedule
+
+The current schedule is:
+
+| Transaction                       | Cost                  | Notes                                                                                                         |
+| --------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------|
+| `Transfer`                        | From 0.05 XEM         | Depends on the XEM amount, attached mosaics, and message length. See [Fees](./transfer_transactions.md#fees). |
+| `Account Key Link`                | 0.15 XEM              |                                                                                                               |
+| `Multisig Account Modification`   | 0.5 XEM               | Paid by the multisig account (or, when converting a regular account into a multisig, by that account).        |
+| `Multisig Cosignature`            | 0.15 XEM              | Paid by the multisig account, not the cosignatory.                                                            |
+| `Multisig` (wrapper)              | 0.15 XEM              | Paid by the multisig account, on top of the inner transaction's fee.                                          |
+| `Namespace Registration`          | 0.15 XEM              | Plus a [lease fee](./namespaces.md#lease-fee) paid to a network sink address.                                 |
+| `Mosaic Definition`               | 0.15 XEM              | Plus a [creation fee](./mosaics.md#creation-fee) paid to a network sink address.                              |
+| `Mosaic Supply Change`            | 0.15 XEM              |                                                                                                               |
+
+### Floor and Bidding
+
+The amounts in the schedule are minimums.
+A transaction whose fee is below the minimum is rejected by validators.
+
+A higher fee than the minimum is accepted and increases the chance of inclusion:
+
+* When a harvester builds a block, it picks transactions sorted by fee, highest first.
+* During network congestion, a node's spam filter ranks pending transactions by a combination of the signer's
+    <importance:> and a small fee bonus, so higher-fee transactions are more likely to enter the <unconfirmed pool:>.
+
+`Multisig Cosignature` fees are additionally capped at 1000 XEM, which protects the multisig account from being drained
+by a single cosignatory bidding an extreme fee.

--- a/mkdocs/pages/en/textbook/transfer_transactions.md
+++ b/mkdocs/pages/en/textbook/transfer_transactions.md
@@ -142,7 +142,7 @@ For a XEM-only transfer, the fee scales with the amount sent:
 
 | Amount sent                  | Cost      |
 | ---------------------------- | --------- |
-| Up to 10'000 XEM             | 0.05 XEM  |
+| Up to 19'999 XEM             | 0.05 XEM  |
 | Each additional 10'000 XEM   | +0.05 XEM |
 | 250'000 XEM or more          | 1.25 XEM  |
 
@@ -165,15 +165,16 @@ The minimum per-mosaic fee is **0.05 XEM**.
     **1. XEM-equivalent value**
 
     \[
-    \text{xem\_equivalent} \approx \frac{8.999 \times 10^9 \cdot \text{atomic\_quantity} \cdot \text{multiplier}}{\text{total\_atomic\_supply}}
+    \text{xem\_equivalent} = \frac{\text{8'999'999'999} \cdot \text{atomic\_quantity} \cdot \text{multiplier}}{\text{total\_atomic\_supply}}
     \]
 
     where:
 
-    * `8.999 × 10^9` is the initial XEM supply, in whole units.
-    * `atomic_quantity` is the amount of the mosaic being transferred, in atomic units.
-    * `multiplier` is the [XEM-amount multiplier](#xem-amount) (typically 1).
-    * `total_atomic_supply` is the mosaic's total supply, in atomic units: `supply × 10^divisibility`.
+    * $\text{8'999'999'999}$ is the initial XEM supply, in whole units.
+    * $\text{atomic\_quantity}$ is the amount of the mosaic being transferred, in atomic units.
+    * $\text{multiplier}$ is the [XEM-amount multiplier](#xem-amount) (typically 1).
+    * $\text{total\_atomic\_supply}$ is the mosaic's total supply, in atomic units:
+        $\text{supply} \cdot 10^{\text{divisibility}}$.
 
     **2. Base fee**
 
@@ -185,14 +186,27 @@ The minimum per-mosaic fee is **0.05 XEM**.
     A **supply discount** is then subtracted from that base fee:
 
     \[
-    \text{discount} = \left\lfloor 0.8 \cdot \ln \!\left( \frac{9 \times 10^{15}}{\text{total\_atomic\_supply}} \right) \right\rfloor \cdot 0.05 \text{ XEM}
+    \text{discount} = \left\lfloor 0.8 \cdot \ln \!\left( \frac{9 \cdot 10^{15}}{\text{total\_atomic\_supply}} \right) \right\rfloor \cdot 0.05 \text{ XEM}
     \]
 
-    where `9 × 10^15` is the largest mosaic quantity NEM allows.
+    where $9 \cdot 10^{15}$ is the largest mosaic quantity NEM allows.
 
-    Scarcer mosaics receive a larger discount, because the logarithm grows as the supply shrinks.
-
+    $\text{xem\_equivalent}$ grows as the mosaic's supply shrinks, so without the discount low-supply mosaics would hit
+    the $1.25$ XEM cap on tiny transfers.
+    The discount counteracts this with a logarithm of that same supply, so scarcer mosaics get a larger correction.
     The final fee is **never less than 0.05 XEM**, even when the discount exceeds the base fee.
+
+    **Example**
+
+    A mosaic with supply $\text{1'000'000}$ and divisibility $0$, sending $100$ units with multiplier $1$:
+
+    1. **XEM-equivalent**: $\frac{\text{8'999'999'999} \cdot 100 \cdot 1}{\text{1'000'000}} = \text{899'999.9999}$.
+    2. **Base fee**: The XEM-only schedule above adds $0.05$ XEM per $\text{10'000}$ XEM of value,
+        with a $1.25$ XEM cap at $\text{250'000}$ XEM or more.
+        Since $\text{899'999.9999}$ exceeds $\text{250'000}$, the base fee is the maximum: $1.25$ XEM.
+    3. **Supply discount**: $\left\lfloor 0.8 \cdot \ln \!\left( \frac{9 \cdot 10^{15}}{\text{1'000'000}} \right) \right\rfloor \cdot 0.05 = 0.90$ XEM.
+
+    **Final fee**: $1.25 - 0.90 = 0.35$ XEM.
 
 ### Message Fee
 

--- a/mkdocs/pages/en/textbook/transfer_transactions.md
+++ b/mkdocs/pages/en/textbook/transfer_transactions.md
@@ -127,3 +127,86 @@ plaintext under AES-CBC and **996 bytes** under AES-GCM.
     Nodes accept and store both schemes under the same `0x0002` flag without inspecting the payload.
     A recipient can only decrypt a secure message when its tooling implements the same scheme the sender used.
     Messages produced by GCM tooling cannot be decrypted by CBC-only tooling, and vice versa.
+
+## Fees
+
+A transfer transaction's fee depends on what is sent.
+It is the sum of two components:
+
+* The **transfer fee**, based on the XEM amount or the attached mosaics.
+* The **message fee**, based on the length of any attached message.
+
+### Transfer Fee
+
+For a XEM-only transfer, the fee scales with the amount sent:
+
+| Amount sent                  | Cost      |
+| ---------------------------- | --------- |
+| Up to 10'000 XEM             | 0.05 XEM  |
+| Each additional 10'000 XEM   | +0.05 XEM |
+| 250'000 XEM or more          | 1.25 XEM  |
+
+For a mosaic transfer, the fee is the sum of every attached mosaic's individual fee.
+Each mosaic is priced as follows:
+
+* **Tiny, indivisible mosaics** (supply ≤ 10'000 and divisibility 0) pay a flat **0.05 XEM**.
+* **All other mosaics** are priced from their **XEM-equivalent value**, derived from the transferred quantity and the
+    mosaic's total supply.
+    This value maps to the same 0.05-to-1.25 XEM fee tiers used for XEM-only transfers, with a **supply discount**
+    that grows as the mosaic's total supply shrinks.
+
+The minimum per-mosaic fee is **0.05 XEM**.
+
+??? info "Mosaic Fee Calculation"
+
+    Computing a non-tiny mosaic's fee takes three steps: compute the transferred quantity's XEM-equivalent value,
+    look that value up on the fee tiers to get a base fee, then subtract the supply discount.
+
+    **1. XEM-equivalent value**
+
+    \[
+    \text{xem\_equivalent} \approx \frac{8.999 \times 10^9 \cdot \text{atomic\_quantity} \cdot \text{multiplier}}{\text{total\_atomic\_supply}}
+    \]
+
+    where:
+
+    * `8.999 × 10^9` is the initial XEM supply, in whole units.
+    * `atomic_quantity` is the amount of the mosaic being transferred, in atomic units.
+    * `multiplier` is the [XEM-amount multiplier](#xem-amount) (typically 1).
+    * `total_atomic_supply` is the mosaic's total supply, in atomic units: `supply × 10^divisibility`.
+
+    **2. Base fee**
+
+    The resulting value is then priced on the same 0.05-to-1.25 XEM fee tiers as a XEM-only transfer,
+    yielding the mosaic's **base fee**.
+
+    **3. Supply discount**
+
+    A **supply discount** is then subtracted from that base fee:
+
+    \[
+    \text{discount} = \left\lfloor 0.8 \cdot \ln \!\left( \frac{9 \times 10^{15}}{\text{total\_atomic\_supply}} \right) \right\rfloor \cdot 0.05 \text{ XEM}
+    \]
+
+    where `9 × 10^15` is the largest mosaic quantity NEM allows.
+
+    Scarcer mosaics receive a larger discount, because the logarithm grows as the supply shrinks.
+
+    The final fee is **never less than 0.05 XEM**, even when the discount exceeds the base fee.
+
+### Message Fee
+
+A non-empty message costs **0.05 XEM** as a base, plus **0.05 XEM** for every additional 32 bytes of
+payload, up to the 1024-byte maximum:
+
+| Message length         | Added cost |
+| ---------------------- | ---------- |
+| No message             | —          |
+| 1 to 31 bytes          | 0.05 XEM   |
+| 32 to 63 bytes         | 0.10 XEM   |
+| 64 to 95 bytes         | 0.15 XEM   |
+| …                      | …          |
+| 1024 bytes (maximum)   | 1.65 XEM   |
+
+The fee is calculated on the stored payload size, so [secure messages](#secure-message-conventions) are billed on their
+encrypted payload, not the plaintext.

--- a/mkdocs/snippets/devbook/transactions/transfer_xem.log
+++ b/mkdocs/snippets/devbook/transactions/transfer_xem.log
@@ -1,0 +1,34 @@
+Using node http://libertalia.nemtest.net:7890
+Fetching current network time from /time-sync/network-time
+  Network time: 351947283 s since the nemesis block
+  Transaction fee: 0.05 XEM
+Built transaction:
+{
+  type: 257,
+  version: 2,
+  network: 152,
+  timestamp: 351947283,
+  signerPublicKey: '462EE976890916E54FA825D26BDD0235F5EB5B6A143C199AB0AE5EE9328E08CE',
+  signature: '17FF7D37A63F3CFC43C790300A7B7F1C8A2A2B1C5D64546007C7D02C771516EE8872A6BBAE414486DC2D4750BBAACB41B3140D45CC319F51B7CBC1D524545C06',
+  fee: '50000',
+  deadline: 351954483,
+  recipientAddress: '5442554C4541554732435A51495355523434324857413655414B47574958484441424A5649505334',
+  amount: '1000000',
+  mosaics: []
+}
+Announcing transaction to /transaction/announce
+  Result: SUCCESS
+Waiting for confirmation from /transaction/get?hash=436A43BDD3CE1F0A5A5EFC40A9027D3732D59AB3C507818A1B436EC7B32BF099
+  Transaction status: pending
+  Transaction status: pending
+  Transaction status: pending
+  Transaction status: pending
+  Transaction status: pending
+  Transaction status: pending
+  Transaction status: pending
+  Transaction status: pending
+  Transaction status: pending
+  Transaction status: pending
+  Transaction status: pending
+  Transaction status: pending
+Transaction confirmed in block 626588

--- a/mkdocs/snippets/devbook/transactions/transfer_xem.mjs
+++ b/mkdocs/snippets/devbook/transactions/transfer_xem.mjs
@@ -1,21 +1,23 @@
 import { PrivateKey } from 'symbol-sdk';
 import { NemFacade } from 'symbol-sdk/nem';
 
-const NODE_URL = 'http://libertalia.nemtest.net:7890';
+const NODE_URL = process.env.NODE_URL ||
+	'http://libertalia.nemtest.net:7890';
 console.log('Using node', NODE_URL);
 // [>step-1]
 const SIGNER_PRIVATE_KEY = process.env.SIGNER_PRIVATE_KEY ||
 	'0000000000000000000000000000000000000000000000000000000000000000';
 const signerKeyPair = new NemFacade.KeyPair(
 	new PrivateKey(SIGNER_PRIVATE_KEY));
+
 const RECIPIENT_ADDRESS = process.env.RECIPIENT_ADDRESS ||
 	'TBULEAUG2CZQISUR442HWA6UAKGWIXHDABJVIPS4';
 // [<step-1]
 const facade = new NemFacade('testnet');
+
 // Define the amount of XEM to transfer [>step-2]
-const xem = parseInt(process.env.XEM_AMOUNT || '1', 10);
-// Convert XEM to atomic units (XEM has a divisibility of 6)
-const amount = BigInt(xem * 1_000_000);
+const xem = parseFloat(process.env.XEM_AMOUNT || '1');
+const amount = BigInt(Math.round(xem * 1_000_000));
 // [<step-2]
 
 try {

--- a/mkdocs/snippets/devbook/transactions/transfer_xem.mjs
+++ b/mkdocs/snippets/devbook/transactions/transfer_xem.mjs
@@ -73,6 +73,7 @@ try {
 		const statusPath = `/transaction/get?hash=${transactionHash}`;
 		console.log('Waiting for confirmation from', statusPath);
 
+		let isConfirmed = false;
 		for (let attempt = 1; 120 >= attempt; ++attempt) {
 			const response = await fetch(`${NODE_URL}${statusPath}`);
 
@@ -80,13 +81,14 @@ try {
 				const confirmed = await response.json();
 				console.log('Transaction confirmed in block',
 					confirmed.meta.height);
+				isConfirmed = true;
 				break;
 			}
 			console.log('  Transaction status: pending');
 			await new Promise(resolve => { setTimeout(resolve, 1000); });
-			if (120 === attempt)
-				console.warn('Confirmation took too long.');
 		}
+		if (!isConfirmed)
+			console.warn('Confirmation took too long.');
 	} else {
 		console.log('Transaction rejected:', announceResult.message);
 	}

--- a/mkdocs/snippets/devbook/transactions/transfer_xem.mjs
+++ b/mkdocs/snippets/devbook/transactions/transfer_xem.mjs
@@ -1,0 +1,96 @@
+import { PrivateKey } from 'symbol-sdk';
+import { NemFacade } from 'symbol-sdk/nem';
+
+const NODE_URL = 'http://libertalia.nemtest.net:7890';
+console.log('Using node', NODE_URL);
+// [>step-1]
+const SIGNER_PRIVATE_KEY = process.env.SIGNER_PRIVATE_KEY ||
+	'0000000000000000000000000000000000000000000000000000000000000000';
+const signerKeyPair = new NemFacade.KeyPair(
+	new PrivateKey(SIGNER_PRIVATE_KEY));
+const RECIPIENT_ADDRESS = process.env.RECIPIENT_ADDRESS ||
+	'TBULEAUG2CZQISUR442HWA6UAKGWIXHDABJVIPS4';
+// [<step-1]
+const facade = new NemFacade('testnet');
+// Define the amount of XEM to transfer [>step-2]
+const xem = parseInt(process.env.XEM_AMOUNT || '1', 10);
+// Convert XEM to atomic units (XEM has a divisibility of 6)
+const amount = BigInt(xem * 1_000_000);
+// [<step-2]
+
+try {
+	// Fetch current network time [>step-3]
+	const timePath = '/time-sync/network-time';
+	console.log('Fetching current network time from', timePath);
+	const timeResponse = await fetch(`${NODE_URL}${timePath}`);
+	const timeJSON = await timeResponse.json();
+	const networkTime = Math.floor(timeJSON.receiveTimeStamp / 1000);
+	console.log('  Network time:', networkTime,
+		's since the nemesis block');
+
+	// Derived fields from network time
+	const timestamp = networkTime;
+	const deadline = networkTime + (2 * 60 * 60);
+	// [<step-3]
+	// Calculate the transaction fee [>step-4]
+	const feeSteps = Math.max(1, Math.min(25, Math.floor(xem / 10_000)));
+	const fee = BigInt(feeSteps * 50_000);
+	console.log(`  Transaction fee: ${Number(fee) / 1_000_000} XEM`);
+	// [<step-4]
+	// Build the transaction [>step-5]
+	const transaction = facade.transactionFactory.create({
+		type: 'transfer_transaction_v2',
+		signerPublicKey: signerKeyPair.publicKey.toString(),
+		fee,
+		timestamp,
+		deadline,
+		recipientAddress: RECIPIENT_ADDRESS,
+		amount
+	});
+	// [<step-5]
+	// Sign transaction and generate final payload [>step-6]
+	const signature = facade.signTransaction(signerKeyPair, transaction);
+	const jsonPayload = facade.transactionFactory.static.attachSignature(
+		transaction, signature);
+	console.log('Built transaction:');
+	console.dir(transaction.toJson(), { colors: true });
+	// [<step-6]
+	// Announce the transaction [>step-7]
+	const announcePath = '/transaction/announce';
+	console.log('Announcing transaction to', announcePath);
+	const announceResponse = await fetch(`${NODE_URL}${announcePath}`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: jsonPayload
+	});
+	const announceResult = await announceResponse.json();
+	console.log('  Result:', announceResult.message);
+	// [<step-7]
+	// Wait for confirmation [>step-8]
+	if ('SUCCESS' === announceResult.message) {
+		const transactionHash = facade.hashTransaction(transaction)
+			.toString();
+		const statusPath = `/transaction/get?hash=${transactionHash}`;
+		console.log('Waiting for confirmation from', statusPath);
+
+		for (let attempt = 1; 120 >= attempt; ++attempt) {
+			const response = await fetch(`${NODE_URL}${statusPath}`);
+
+			if (response.ok) {
+				const confirmed = await response.json();
+				console.log('Transaction confirmed in block',
+					confirmed.meta.height);
+				break;
+			}
+			console.log('  Transaction status: pending');
+			await new Promise(resolve => { setTimeout(resolve, 1000); });
+			if (120 === attempt)
+				console.warn('Confirmation took too long.');
+		}
+	} else {
+		console.log('Transaction rejected:', announceResult.message);
+	}
+	// [<step-8]
+} catch (e) {
+	console.error(e.message, '| Cause:', e.cause?.code ?? 'unknown');
+}

--- a/mkdocs/snippets/devbook/transactions/transfer_xem.py
+++ b/mkdocs/snippets/devbook/transactions/transfer_xem.py
@@ -14,15 +14,16 @@ SIGNER_PRIVATE_KEY = os.getenv(
 	'SIGNER_PRIVATE_KEY',
 	'0000000000000000000000000000000000000000000000000000000000000000')
 signer_key_pair = NemFacade.KeyPair(PrivateKey(SIGNER_PRIVATE_KEY))
+
 RECIPIENT_ADDRESS = os.getenv(
 	'RECIPIENT_ADDRESS',
 	'TBULEAUG2CZQISUR442HWA6UAKGWIXHDABJVIPS4')
 # [<step-1]
 facade = NemFacade('testnet')
+
 # Define the amount of XEM to transfer [>step-2]
-xem = int(os.getenv('XEM_AMOUNT', '1'))
-# Convert XEM to atomic units (XEM has a divisibility of 6)
-amount = xem * 1_000_000
+xem = float(os.getenv('XEM_AMOUNT', '1'))
+amount = round(xem * 1_000_000)
 # [<step-2]
 
 try:

--- a/mkdocs/snippets/devbook/transactions/transfer_xem.py
+++ b/mkdocs/snippets/devbook/transactions/transfer_xem.py
@@ -80,6 +80,7 @@ try:
 			f'/transaction/get?hash={
 				facade.hash_transaction(transaction)}')
 		print(f'Waiting for confirmation from {status_path}')
+		is_confirmed = False
 		for attempt in range(120):
 			try:
 				with urllib.request.urlopen(
@@ -88,11 +89,12 @@ try:
 					confirmed = json.loads(response.read().decode())
 					height = confirmed['meta']['height']
 					print(f'Transaction confirmed in block {height}')
+					is_confirmed = True
 					break
 			except urllib.error.HTTPError:
 				print('  Transaction status: pending')
 			time.sleep(1)
-		else:
+		if not is_confirmed:
 			print('Confirmation took too long.')
 	else:
 		print(f'Transaction rejected: {announce_result['message']}')

--- a/mkdocs/snippets/devbook/transactions/transfer_xem.py
+++ b/mkdocs/snippets/devbook/transactions/transfer_xem.py
@@ -1,0 +1,101 @@
+import json
+import os
+import time
+import urllib.request
+
+from symbolchain.CryptoTypes import PrivateKey
+from symbolchain.facade.NemFacade import NemFacade
+
+NODE_URL = os.getenv('NODE_URL', 'http://libertalia.nemtest.net:7890')
+
+print(f'Using node {NODE_URL}')
+# [>step-1]
+SIGNER_PRIVATE_KEY = os.getenv(
+	'SIGNER_PRIVATE_KEY',
+	'0000000000000000000000000000000000000000000000000000000000000000')
+signer_key_pair = NemFacade.KeyPair(PrivateKey(SIGNER_PRIVATE_KEY))
+RECIPIENT_ADDRESS = os.getenv(
+	'RECIPIENT_ADDRESS',
+	'TBULEAUG2CZQISUR442HWA6UAKGWIXHDABJVIPS4')
+# [<step-1]
+facade = NemFacade('testnet')
+# Define the amount of XEM to transfer [>step-2]
+xem = int(os.getenv('XEM_AMOUNT', '1'))
+# Convert XEM to atomic units (XEM has a divisibility of 6)
+amount = xem * 1_000_000
+# [<step-2]
+
+try:
+	# Fetch current network time [>step-3]
+	time_path = '/time-sync/network-time'
+	print(f'Fetching current network time from {time_path}')
+	with urllib.request.urlopen(f'{NODE_URL}{time_path}') as response:
+		response_json = json.loads(response.read().decode())
+		network_time = response_json['receiveTimeStamp'] // 1000
+		print(f'  Network time: {network_time} s since the nemesis block')
+
+	# Derived fields from network time
+	timestamp = network_time
+	deadline = network_time + 2 * 60 * 60
+	# [<step-3]
+	# Calculate the transaction fee [>step-4]
+	fee_steps = max(1, min(25, xem // 10_000))
+	fee = fee_steps * 50_000
+	print(f'  Transaction fee: {fee / 1_000_000} XEM')
+	# [<step-4]
+	# Build the transaction [>step-5]
+	transaction = facade.transaction_factory.create({
+		'type': 'transfer_transaction_v2',
+		'signer_public_key': signer_key_pair.public_key,
+		'fee': fee,
+		'timestamp': timestamp,
+		'deadline': deadline,
+		'recipient_address': RECIPIENT_ADDRESS,
+		'amount': amount
+	})
+	# [<step-5]
+	# Sign transaction and generate final payload [>step-6]
+	signature = facade.sign_transaction(signer_key_pair, transaction)
+	json_payload = facade.transaction_factory.attach_signature(
+		transaction, signature)
+	print('Built transaction:')
+	print(json.dumps(transaction.to_json(), indent=2))
+	# [<step-6]
+	# Announce the transaction [>step-7]
+	announce_path = '/transaction/announce'
+	print(f'Announcing transaction to {announce_path}')
+	announce_request = urllib.request.Request(
+		f'{NODE_URL}{announce_path}',
+		data=json_payload.encode(),
+		headers={'Content-Type': 'application/json'},
+		method='POST'
+	)
+	with urllib.request.urlopen(announce_request) as response:
+		announce_result = json.loads(response.read().decode())
+	print(f'  Result: {announce_result['message']}')
+	# [<step-7]
+	# Wait for confirmation [>step-8]
+	if 'SUCCESS' == announce_result['message']:
+		status_path = (
+			f'/transaction/get?hash={
+				facade.hash_transaction(transaction)}')
+		print(f'Waiting for confirmation from {status_path}')
+		for attempt in range(120):
+			try:
+				with urllib.request.urlopen(
+					f'{NODE_URL}{status_path}'
+				) as response:
+					confirmed = json.loads(response.read().decode())
+					height = confirmed['meta']['height']
+					print(f'Transaction confirmed in block {height}')
+					break
+			except urllib.error.HTTPError:
+				print('  Transaction status: pending')
+			time.sleep(1)
+		else:
+			print('Confirmation took too long.')
+	else:
+		print(f'Transaction rejected: {announce_result['message']}')
+	# [<step-8]
+except urllib.error.URLError as e:
+	print(e.reason)


### PR DESCRIPTION
Adapts the [transfer transaction](https://docs.symboltest.net/en/devbook/transactions/transfer/) tutorial to NEM.

Note: We'll have a separate one for transferring mosaics.