### PR TITLE
[mkdocs] docs: add monitoring status tutorial

### DIFF
--- a/mkdocs/config/mkdocs.en.yml
+++ b/mkdocs/config/mkdocs.en.yml
@@ -88,6 +88,7 @@ nav:
               - devbook/accounts/query-balance.md
           - Transactions:
               - devbook/transactions/transfer-xem.md
+              - devbook/transactions/monitoring-status.md
       - Reference Guides:
           - Python SDK: devbook/reference/py/
           - TypeScript SDK: devbook/reference/ts/

--- a/mkdocs/pages/en/devbook/transactions/monitoring-status.md
+++ b/mkdocs/pages/en/devbook/transactions/monitoring-status.md
@@ -1,0 +1,178 @@
+---
+title: Transaction Status
+tutorial_level: beginner
+---
+
+# Monitoring Transaction Status
+
+When a <transaction:> is announced to the NEM network and accepted, it enters the <unconfirmed pool:>, where it remains
+until it is included in a <block:>.
+An invalid transaction never gets that far: the receiving <node:> rejects it immediately when announced, as shown in the
+[Transfer XEM tutorial](./transfer-xem.md#announcing-the-transaction).
+
+Acceptance is not confirmation, though.
+The network exposes the transaction's progress but does not push it to the sender, so applications that need to react to
+confirmation or failure must check for status changes themselves.
+
+This tutorial shows how to monitor a transaction's status until it is confirmed, how to check whether a transaction that
+has not yet confirmed is still in the unconfirmed pool, and how to decide when a transaction will never confirm.
+Along the way, you will gain a practical understanding of the
+[transaction lifecycle](../../textbook/transactions.md#transaction-lifecycle).
+
+!!! note "Confirmed transactions can still be reversed"
+    A confirmed transaction has been included in a block but is not yet irreversible.
+    Until enough subsequent blocks are added to surpass the <rewrite limit:>, <rollbacks:> are still possible.
+
+## Prerequisites
+
+This tutorial uses the [NEM REST API](../reference/rest/nem.md) without requiring an SDK.
+You only need a way to make HTTP requests.
+
+## Full Code
+
+This tutorial uses polling to check the transaction status.
+Polling is used here for illustration purposes, but it is not the recommended approach for production applications.
+
+{% import 'tutorial.jinja2' as tutorial with context %}
+
+{{ tutorial.code_full_tagged('devbook/transactions/monitoring_status', ['py', 'js']) }}
+
+The snippet uses the `NODE_URL` environment variable to set the NEM API node.
+If no value is provided, a default one is used.
+
+## Code Explanation
+
+### Finding the Transaction Hash, Address, and Signature
+
+{{ tutorial.code_snippet_tagged('step-1') }}
+
+To monitor a transaction, you need its hash, which is generated after signing.
+The hash uniquely identifies the transaction on the NEM network.
+
+The snippet also reads a **signer's address** and the **transaction signature**.
+Neither is needed to detect confirmation, but both are used to diagnose a transaction that does not confirm within
+the polling window.
+
+The snippet uses sample values.
+Set `TRANSACTION_HASH`, `SIGNER_ADDRESS`, and `TRANSACTION_SIGNATURE` environment variables to override them.
+All three values are produced when signing a transaction, as shown in the [Transfer XEM tutorial](./transfer-xem.md).
+
+### Polling for Confirmation
+
+{{ tutorial.code_snippet_tagged('step-2') }}
+
+The {{ tutorial.var('wait_for_transaction_confirmation') }} function polls a transaction until it is confirmed.
+It queries <get:/transaction/get> with the transaction hash up to 120 times by default, sleeping 1 second between
+attempts (about two minutes in total), so monitoring eventually stops even if the transaction never confirms.
+
+When the transaction has been included in a block, the endpoint returns it together with the block height under
+`meta.height`, and the function returns successfully.
+
+Otherwise, the endpoint responds with HTTP `400` ("Hash was not found in cache") and the function logs the attempt as
+`pending` and continues polling.
+
+!!! warning "Hash lookup is short-lived"
+
+    <get:/transaction/get> reads from an in-memory cache with a default retention of 36 hours.
+    The lookup is enabled by default, but node operators can disable it or change the retention.
+    After the retention period, a confirmed transaction returns the same HTTP `400` error.
+
+    For long-term lookups, store `meta.height` on confirmation and fetch the block by height via
+    <post:/block/at/public>.
+
+If the loop ends without a confirmation, the function returns `False`.
+This means the transaction was not confirmed within the polling window, not that it failed, and the next function
+answers whether it is still in the <unconfirmed pool:>.
+
+### Inspecting the Unconfirmed Pool
+
+{{ tutorial.code_snippet_tagged('step-3') }}
+
+{{ tutorial.var('is_in_unconfirmed_pool') }} queries <get:/account/unconfirmedTransactions> for the signer's address and
+reports whether the monitored transaction is among them.
+
+The endpoint response omits each entry's hash, so the function matches by **signature** instead.
+A transaction's signature is unique and appears under `transaction.signature` in every pool entry.
+For multisig transactions, this is the signature of the announced wrapper, not of the inner transaction.
+
+The function returns:
+
+* `True`: the transaction is still in the unconfirmed pool, waiting for a block.
+* `False`: the transaction is not in the response, because it has not arrived at this node yet, because it was dropped
+    from the pool, or because it was pushed out by the entry cap.
+
+    !!! warning "The pool view is capped at 25 entries"
+
+        The endpoint returns at most the 25 most recent entries involving the address.
+        Incoming transactions count toward this cap too, so on a busy account the monitored transaction can drop out of
+        the response while it is still in the pool.
+
+??? info "Alternative: hash-based matching"
+
+    Each pool entry can be rebuilt using <dy:TransactionFactory.create> and hashed with <dy:NemFacade.hashTransaction>
+    to compare against the monitored hash.
+    However, rebuilding requires mapping the REST fields to a typed descriptor for every transaction type, which is
+    why the snippet matches by signature instead.
+
+### Putting Both Functions Together
+
+{{ tutorial.code_snippet_tagged('step-4') }}
+
+The snippet combines both functions: when {{ tutorial.var('wait_for_transaction_confirmation') }} ends without a
+confirmation, {{ tutorial.var('is_in_unconfirmed_pool') }} diagnoses whether the transaction is still in the unconfirmed
+pool.
+
+!!! note "Detecting rejected transactions"
+
+    A node keeps no record of dropped transactions, and other nodes may still hold the transaction as unconfirmed,
+    so a missing transaction is not necessarily a failed one.
+
+    The transaction's **deadline** gives the definitive verdict.
+    Blocks cannot include a transaction whose deadline has passed, so once the current <network time:> moves past
+    the deadline, the transaction will never confirm.
+
+    To decide whether to keep waiting or to announce a new transaction, compare the deadline chosen when
+    [building the transaction](./transfer-xem.md#fetching-network-time) against the network time from
+    <get:/time-sync/network-time>.
+
+## Output
+
+The following output shows a typical run monitoring a freshly-announced transaction:
+
+```text
+--8<-- 'devbook/transactions/monitoring_status.log'
+```
+
+The output shows:
+
+1. The transaction hash being monitored.
+2. Several polling attempts reporting `pending` while the transaction is being processed.
+3. The successful inclusion in a block on a later attempt.
+4. A success message when the transaction is confirmed.
+
+The number of attempts and timing vary depending on network conditions and block production rate.
+
+To see the transaction from the network's perspective, visit the [NEM Testnet Explorer](https://testnet.nem.fyi/) and
+search for the transaction hash.
+
+## Conclusion
+
+This tutorial showed how to:
+
+| Step                                                                             | Related documentation                  |
+| -------------------------------------------------------------------------------- | -------------------------------------- |
+| [Poll for confirmation](#polling-for-confirmation)                               | <get:/transaction/get>                 |
+| [Inspect the unconfirmed pool](#inspecting-the-unconfirmed-pool)                 | <get:/account/unconfirmedTransactions> |
+| [Detect when a transaction will never confirm](#putting-both-functions-together) | <get:/time-sync/network-time>          |
+
+## Next steps
+
+For production applications, consider these improvements:
+
+* **Re-check confirmation after a negative pool result.** The transaction may confirm in the gap between the
+    polling timeout and the pool check, so query <get:/transaction/get> once more before reacting.
+* **Wait past the rewrite limit.** A confirmed transaction can still be rolled back until enough subsequent
+    blocks have been added.
+    See the <rewrite limit:> for the practical threshold.
+* **Query multiple nodes.** Check status across several <nodes:> for greater reliability and protection against
+    single-node issues.

--- a/mkdocs/pages/en/devbook/transactions/monitoring-status.md
+++ b/mkdocs/pages/en/devbook/transactions/monitoring-status.md
@@ -5,23 +5,24 @@ tutorial_level: beginner
 
 # Monitoring Transaction Status
 
-When a <transaction:> is announced to the NEM network and accepted, it enters the <unconfirmed pool:>, where it remains
-until it is included in a <block:>.
-An invalid transaction never gets that far: the receiving <node:> rejects it immediately when announced, as shown in the
-[Transfer XEM tutorial](./transfer-xem.md#announcing-the-transaction).
+After announcing a <transaction:> to the NEM network, it remains unconfirmed until it is included in a <block:>.
 
-Acceptance is not confirmation, though.
-The network exposes the transaction's progress but does not push it to the sender, so applications that need to react to
-confirmation or failure must check for status changes themselves.
+Monitoring status changes is essential for building responsive applications that can react to transaction confirmation
+or failure.
 
-This tutorial shows how to monitor a transaction's status until it is confirmed, how to check whether a transaction that
-has not yet confirmed is still in the unconfirmed pool, and how to decide when a transaction will never confirm.
-Along the way, you will gain a practical understanding of the
-[transaction lifecycle](../../textbook/transactions.md#transaction-lifecycle).
+This tutorial shows how to monitor a transaction's status until it is confirmed, how to check whether it is still
+waiting in the <unconfirmed pool:>, and how to decide when it will never confirm.
 
-!!! note "Confirmed transactions can still be reversed"
-    A confirmed transaction has been included in a block but is not yet irreversible.
-    Until enough subsequent blocks are added to surpass the <rewrite limit:>, <rollbacks:> are still possible.
+This kind of monitoring typically happens right after announcing a transaction, as shown in the
+[Transfer XEM tutorial](./transfer-xem.md), to make sure it gets confirmed.
+
+!!! note "Polling is not recommended for production"
+
+    This tutorial uses polling to check the transaction status.
+    Polling is used here for illustration purposes, but it is not the recommended approach for production applications.
+
+    [WebSockets](../reference/websockets/index.md) provide a more responsive solution without the overhead of repeated
+    API calls.
 
 ## Prerequisites
 
@@ -30,15 +31,21 @@ You only need a way to make HTTP requests.
 
 ## Full Code
 
-This tutorial uses polling to check the transaction status.
-Polling is used here for illustration purposes, but it is not the recommended approach for production applications.
-
 {% import 'tutorial.jinja2' as tutorial with context %}
 
 {{ tutorial.code_full_tagged('devbook/transactions/monitoring_status', ['py', 'js']) }}
 
 The snippet uses the `NODE_URL` environment variable to set the NEM API node.
 If no value is provided, a default one is used.
+
+The tutorial first defines the following reusable functions:
+
+* {{ tutorial.var('get_confirmation_height()') }}: Checks whether the transaction has been confirmed.
+* {{ tutorial.var('is_in_unconfirmed_pool()') }}: Reports whether the transaction is waiting in the <unconfirmed pool:>.
+* {{ tutorial.var('wait_for_confirmation()') }}: Repeats the confirmation check until the transaction is confirmed or
+    the attempts run out.
+
+It then calls them together to monitor the transaction, as shown in [Putting It All Together](#putting-it-all-together).
 
 ## Code Explanation
 
@@ -50,39 +57,38 @@ To monitor a transaction, you need its hash, which is generated after signing.
 The hash uniquely identifies the transaction on the NEM network.
 
 The snippet also reads a **signer's address** and the **transaction signature**.
-Neither is needed to detect confirmation, but both are used to diagnose a transaction that does not confirm within
-the polling window.
+Neither is needed to detect confirmation, but both are used to check whether a transaction is still waiting in the
+<unconfirmed pool:>.
 
 The snippet uses sample values.
 Set `TRANSACTION_HASH`, `SIGNER_ADDRESS`, and `TRANSACTION_SIGNATURE` environment variables to override them.
 All three values are produced when signing a transaction, as shown in the [Transfer XEM tutorial](./transfer-xem.md).
 
-### Polling for Confirmation
+### Checking for Confirmation
 
 {{ tutorial.code_snippet_tagged('step-2') }}
 
-The {{ tutorial.var('wait_for_transaction_confirmation') }} function polls a transaction until it is confirmed.
-It queries <get:/transaction/get> with the transaction hash up to 120 times by default, sleeping 1 second between
-attempts (about two minutes in total), so monitoring eventually stops even if the transaction never confirms.
+The {{ tutorial.var('get_confirmation_height') }} function checks whether the transaction is confirmed by querying
+<get:/transaction/get> with the transaction hash.
 
 When the transaction has been included in a block, the endpoint returns it together with the block height under
-`meta.height`, and the function returns successfully.
+`meta.height`, and the function returns that height.
 
-Otherwise, the endpoint responds with HTTP `400` ("Hash was not found in cache") and the function logs the attempt as
-`pending` and continues polling.
+Otherwise, the endpoint responds with HTTP `400` ("Hash was not found in cache") and the function returns no height,
+meaning the transaction is not confirmed yet.
+A transaction that is not confirmed may still be waiting in the <unconfirmed pool:>, which the next function inspects.
 
 !!! warning "Hash lookup is short-lived"
 
     <get:/transaction/get> reads from an in-memory cache with a default retention of 36 hours.
     The lookup is enabled by default, but node operators can disable it or change the retention.
-    After the retention period, a confirmed transaction returns the same HTTP `400` error.
 
-    For long-term lookups, store `meta.height` on confirmation and fetch the block by height via
-    <post:/block/at/public>.
+    A transaction older than the retention period returns the same HTTP `400` error even if it is confirmed.
+    If a transaction needs to be looked up much later, store its confirmation block height along with its hash, and
+    fetch the containing block via <post:/block/at/public>.
+    The transaction can also be found by paging through the signer's history with <get:/account/transfers/all>.
 
-If the loop ends without a confirmation, the function returns `False`.
-This means the transaction was not confirmed within the polling window, not that it failed, and the next function
-answers whether it is still in the <unconfirmed pool:>.
+    Otherwise, recovering the transaction requires searching the blockchain block by block.
 
 ### Inspecting the Unconfirmed Pool
 
@@ -91,6 +97,11 @@ answers whether it is still in the <unconfirmed pool:>.
 {{ tutorial.var('is_in_unconfirmed_pool') }} queries <get:/account/unconfirmedTransactions> for the signer's address and
 reports whether the monitored transaction is among them.
 
+!!! note "Invalid transactions never enter the pool"
+
+    A transaction that fails validation does not reach the unconfirmed pool: the receiving <node:> rejects it
+    immediately when announced, as shown in the [Transfer XEM tutorial](./transfer-xem.md#announcing-the-transaction).
+
 The endpoint response omits each entry's hash, so the function matches by **signature** instead.
 A transaction's signature is unique and appears under `transaction.signature` in every pool entry.
 For multisig transactions, this is the signature of the announced wrapper, not of the inner transaction.
@@ -98,57 +109,83 @@ For multisig transactions, this is the signature of the announced wrapper, not o
 The function returns:
 
 * `True`: the transaction is still in the unconfirmed pool, waiting for a block.
-* `False`: the transaction is not in the response, because it has not arrived at this node yet, because it was dropped
-    from the pool, or because it was pushed out by the entry cap.
+* `False`: the transaction is not in the response, because it has not arrived at this node yet, because it has already
+    been confirmed, because it was dropped from the pool, or because it was left out of the response.
 
-    !!! warning "The pool view is capped at 25 entries"
+    !!! warning "The response is limited to 25 transactions"
 
-        The endpoint returns at most the 25 most recent entries involving the address.
-        Incoming transactions count toward this cap too, so on a busy account the monitored transaction can drop out of
-        the response while it is still in the pool.
+        The endpoint returns at most the 25 most recent transactions involving the address.
+        Incoming transactions count toward this limit too, so on a busy account the monitored transaction can be missing
+        from the response while it is still in the unconfirmed pool.
 
-??? info "Alternative: hash-based matching"
-
-    Each pool entry can be rebuilt using <dy:TransactionFactory.create> and hashed with <dy:NemFacade.hashTransaction>
-    to compare against the monitored hash.
-    However, rebuilding requires mapping the REST fields to a typed descriptor for every transaction type, which is
-    why the snippet matches by signature instead.
-
-### Putting Both Functions Together
+### Waiting for Confirmation
 
 {{ tutorial.code_snippet_tagged('step-4') }}
 
-The snippet combines both functions: when {{ tutorial.var('wait_for_transaction_confirmation') }} ends without a
-confirmation, {{ tutorial.var('is_in_unconfirmed_pool') }} diagnoses whether the transaction is still in the unconfirmed
-pool.
+The {{ tutorial.var('wait_for_confirmation') }} function calls {{ tutorial.var('get_confirmation_height') }} up to 120
+times by default, sleeping 1 second between attempts (about two minutes in total), so monitoring eventually stops even
+if the transaction never confirms.
 
-!!! note "Detecting rejected transactions"
+The function returns `True` as soon as a check reports a confirmation.
+When the attempts run out, it returns `False` instead.
+This means the transaction was not confirmed within the polling window, not that it failed.
 
-    A node keeps no record of dropped transactions, and other nodes may still hold the transaction as unconfirmed,
-    so a missing transaction is not necessarily a failed one.
+### Putting It All Together
 
-    The transaction's **deadline** gives the definitive verdict.
-    Blocks cannot include a transaction whose deadline has passed, so once the current <network time:> moves past
-    the deadline, the transaction will never confirm.
+{{ tutorial.code_snippet_tagged('step-5') }}
 
-    To decide whether to keep waiting or to announce a new transaction, compare the deadline chosen when
-    [building the transaction](./transfer-xem.md#fetching-network-time) against the network time from
-    <get:/time-sync/network-time>.
+The snippet starts with a single call to {{ tutorial.var('get_confirmation_height') }}: when the transaction is already
+confirmed, there is nothing left to monitor.
+
+!!! warning "Confirmed transactions can still be reversed"
+
+    A confirmed transaction has been included in a block but is not yet irreversible.
+    Until enough subsequent blocks are added to surpass the <rewrite limit:>, <rollbacks:> are still possible.
+
+When it is not, {{ tutorial.var('is_in_unconfirmed_pool') }} decides whether waiting makes sense.
+A transaction that is neither confirmed nor in the pool is not going to confirm from this node's perspective, so the
+snippet reports it and exits.
+
+Only when the transaction is waiting in the pool does the snippet call {{ tutorial.var('wait_for_confirmation') }} to
+poll until the transaction is confirmed or the polling window ends.
+
+!!! note "Only rejection or a passed deadline means failure"
+
+    There are two ways to be sure a transaction will never confirm: it was rejected at announcement, or its **deadline**
+    has passed.
+
+    A transaction dropped from one node's unconfirmed pool may still confirm, because each node keeps its own pool and
+    a peer may still hold it (for example, the node restarted with an empty pool, or evicted the transaction during
+    revalidation).
+
+    Since rejections come back in the announcement response, the **deadline** gives the definitive verdict.
+    Once <network time:> passes it, the transaction can no longer enter a block and it is safe to announce a
+    replacement.
+
+    Compare the deadline chosen when [building the transaction](./transfer-xem.md#fetching-network-time) against the
+    network time from <get:/time-sync/network-time>.
 
 ## Output
 
 The following output shows a typical run monitoring a freshly-announced transaction:
 
-```text
+```text linenums="1" hl_lines="2 4 10 12"
 --8<-- 'devbook/transactions/monitoring_status.log'
 ```
 
-The output shows:
+Some highlights from the output:
 
-1. The transaction hash being monitored.
-2. Several polling attempts reporting `pending` while the transaction is being processed.
-3. The successful inclusion in a block on a later attempt.
-4. A success message when the transaction is confirmed.
+* **Transaction hash** (line 2): The hash of the transaction to monitor, which uniquely identifies it on the network.
+
+* **Polling start** (line 4): Polling only starts when the transaction was not confirmed on the first check but was
+    found waiting in the unconfirmed pool.
+
+* **Polling attempts** (lines 5-9): Each attempt reports `pending` while the transaction waits to be included in a
+    block.
+
+* **Confirmation** (line 10): A polling attempt finally reports the inclusion in block `652601`.
+
+* **Final outcome** (line 12): The transaction is confirmed and monitoring ends.
 
 The number of attempts and timing vary depending on network conditions and block production rate.
 
@@ -159,20 +196,21 @@ search for the transaction hash.
 
 This tutorial showed how to:
 
-| Step                                                                             | Related documentation                  |
-| -------------------------------------------------------------------------------- | -------------------------------------- |
-| [Poll for confirmation](#polling-for-confirmation)                               | <get:/transaction/get>                 |
-| [Inspect the unconfirmed pool](#inspecting-the-unconfirmed-pool)                 | <get:/account/unconfirmedTransactions> |
-| [Detect when a transaction will never confirm](#putting-both-functions-together) | <get:/time-sync/network-time>          |
+| Step                                                                      | Related documentation                   |
+| ------------------------------------------------------------------------- | --------------------------------------- |
+| [Check for confirmation](#checking-for-confirmation)                      | <get:/transaction/get>                  |
+| [Inspect the unconfirmed pool](#inspecting-the-unconfirmed-pool)          | <get:/account/unconfirmedTransactions>  |
+| [Wait for confirmation](#waiting-for-confirmation)                        | <get:/transaction/get>                  |
+| [Detect when a transaction will never confirm](#putting-it-all-together)  | <get:/time-sync/network-time>           |
 
 ## Next steps
 
 For production applications, consider these improvements:
 
-* **Re-check confirmation after a negative pool result.** The transaction may confirm in the gap between the
-    polling timeout and the pool check, so query <get:/transaction/get> once more before reacting.
 * **Wait past the rewrite limit.** A confirmed transaction can still be rolled back until enough subsequent
     blocks have been added.
     See the <rewrite limit:> for the practical threshold.
 * **Query multiple nodes.** Check status across several <nodes:> for greater reliability and protection against
     single-node issues.
+* **Use WebSockets:** Replace polling with WebSocket subscriptions for real-time updates without repeated API calls.
+    See the [Listening to Transaction Flow](../websockets/listen-transaction-flow.md) WebSocket tutorial.

--- a/mkdocs/pages/en/devbook/transactions/monitoring-status.md
+++ b/mkdocs/pages/en/devbook/transactions/monitoring-status.md
@@ -10,7 +10,7 @@ After announcing a <transaction:> to the NEM network, it remains unconfirmed unt
 Monitoring status changes is essential for building responsive applications that can react to transaction confirmation
 or failure.
 
-This tutorial shows how to monitor a transaction's status until it is confirmed, how to check whether it is still
+This tutorial shows how to poll a transaction's status until it is confirmed, how to check whether it is still
 waiting in the <unconfirmed pool:>, and how to decide when it will never confirm.
 
 This kind of monitoring typically happens right after announcing a transaction, as shown in the
@@ -18,8 +18,8 @@ This kind of monitoring typically happens right after announcing a transaction, 
 
 !!! note "Polling is not recommended for production"
 
-    This tutorial uses polling to check the transaction status.
-    Polling is used here for illustration purposes, but it is not the recommended approach for production applications.
+    This tutorial uses polling to check the transaction status for illustration purposes,
+    but it is not the recommended approach for production applications.
 
     [WebSockets](../reference/websockets/index.md) provide a more responsive solution without the overhead of repeated
     API calls.
@@ -40,12 +40,15 @@ If no value is provided, a default one is used.
 
 The tutorial first defines the following reusable functions:
 
-* {{ tutorial.var('get_confirmation_height()') }}: Checks whether the transaction has been confirmed.
-* {{ tutorial.var('is_in_unconfirmed_pool()') }}: Reports whether the transaction is waiting in the <unconfirmed pool:>.
+* {{ tutorial.var('get_confirmation_height()') }}: Checks whether the transaction has been confirmed by <harvesting:>
+    and is already part of the blockchain.
+* {{ tutorial.var('is_in_unconfirmed_pool()') }}: Reports whether the transaction is waiting to be confirmed in the
+    <unconfirmed pool:>.
 * {{ tutorial.var('wait_for_confirmation()') }}: Repeats the confirmation check until the transaction is confirmed or
     the attempts run out.
 
-It then calls them together to monitor the transaction, as shown in [Putting It All Together](#putting-it-all-together).
+The tutorial then calls them together to monitor the transaction,
+as shown in [Putting It All Together](#putting-it-all-together).
 
 ## Code Explanation
 
@@ -71,46 +74,51 @@ All three values are produced when signing a transaction, as shown in the [Trans
 The {{ tutorial.var('get_confirmation_height') }} function checks whether the transaction is confirmed by querying
 <get:/transaction/get> with the transaction hash.
 
-When the transaction has been included in a block, the endpoint returns it together with the block height under
-`meta.height`, and the function returns that height.
+When a transaction has been included in a block, this endpoint returns its contents together with the block height
+in `meta.height`, which the function returns.
 
 Otherwise, the endpoint responds with HTTP `400` ("Hash was not found in cache") and the function returns no height,
-meaning the transaction is not confirmed yet.
+meaning the transaction is not confirmed.
 A transaction that is not confirmed may still be waiting in the <unconfirmed pool:>, which the next function inspects.
 
 !!! warning "Hash lookup is short-lived"
 
-    <get:/transaction/get> reads from an in-memory cache with a default retention of 36 hours.
+    <get:/transaction/get> reads from a cache with a default retention of 36 hours.
     The lookup is enabled by default, but node operators can disable it or change the retention.
 
-    A transaction older than the retention period returns the same HTTP `400` error even if it is confirmed.
-    If a transaction needs to be looked up much later, store its confirmation block height along with its hash, and
-    fetch the containing block via <post:/block/at/public>.
-    The transaction can also be found by paging through the signer's history with <get:/account/transfers/all>.
+    Querying for a transaction hash older than the retention period returns an HTTP `400` error, even if the
+    transaction is in fact confirmed.
 
-    Otherwise, recovering the transaction requires searching the blockchain block by block.
+    Therefore, when announcing a transaction that might need to be looked up later than this retention period,
+    store its confirmation block height along with its hash.
+    In this way, the transaction can be directly retrieved from the block via the <post:/block/at/public> endpoint.
+
+    Otherwise, the transaction needs to be located by paging through the signer's full history with
+    <get:/account/transfers/all>, or by searching the blockchain block by block.
 
 ### Inspecting the Unconfirmed Pool
 
 {{ tutorial.code_snippet_tagged('step-3') }}
 
 {{ tutorial.var('is_in_unconfirmed_pool') }} queries <get:/account/unconfirmedTransactions> for the signer's address and
-reports whether the monitored transaction is among them.
+reports whether the monitored transaction is among the pending list.
 
 !!! note "Invalid transactions never enter the pool"
 
-    A transaction that fails validation does not reach the unconfirmed pool: the receiving <node:> rejects it
-    immediately when announced, as shown in the [Transfer XEM tutorial](./transfer-xem.md#announcing-the-transaction).
+    A transaction that fails [validation](../../textbook/transactions.md#3-validation) does not reach the unconfirmed
+    pool: the receiving <node:> rejects it immediately when announced, as shown in the
+    [Transfer XEM tutorial](./transfer-xem.md#announcing-the-transaction).
 
-The endpoint response omits each entry's hash, so the function matches by **signature** instead.
+The above endpoint response omits each entry's hash, so the function matches by **signature** instead.
 A transaction's signature is unique and appears under `transaction.signature` in every pool entry.
 For multisig transactions, this is the signature of the announced wrapper, not of the inner transaction.
 
 The function returns:
 
-* `True`: the transaction is still in the unconfirmed pool, waiting for a block.
-* `False`: the transaction is not in the response, because it has not arrived at this node yet, because it has already
-    been confirmed, because it was dropped from the pool, or because it was left out of the response.
+* `True`: the transaction is still in the unconfirmed pool, waiting to be included in a block.
+* `False`: the transaction is not in the response.
+    Possible causes include: it has not arrived at this node yet, it has already been confirmed,
+    it was dropped from the pool, or it was left out of the response.
 
     !!! warning "The response is limited to 25 transactions"
 
@@ -122,48 +130,47 @@ The function returns:
 
 {{ tutorial.code_snippet_tagged('step-4') }}
 
-The {{ tutorial.var('wait_for_confirmation') }} function calls {{ tutorial.var('get_confirmation_height') }} up to 120
-times by default, sleeping 1 second between attempts (about two minutes in total), so monitoring eventually stops even
-if the transaction never confirms.
+The {{ tutorial.var('wait_for_confirmation') }} function calls {{ tutorial.var('get_confirmation_height') }} every
+second until the transaction is confirmed, or two minutes ellapse (configurable timeout).
 
 The function returns `True` as soon as a check reports a confirmation.
 When the attempts run out, it returns `False` instead.
-This means the transaction was not confirmed within the polling window, not that it failed.
+This means the transaction was not confirmed within the polling window, not that it failed, but this is a rare case.
 
 ### Putting It All Together
 
 {{ tutorial.code_snippet_tagged('step-5') }}
 
-The snippet starts with a single call to {{ tutorial.var('get_confirmation_height') }}: when the transaction is already
-confirmed, there is nothing left to monitor.
+The snippet starts with a call to {{ tutorial.var('get_confirmation_height') }} to check if the transaction is already
+confirmed.
 
 !!! warning "Confirmed transactions can still be reversed"
 
     A confirmed transaction has been included in a block but is not yet irreversible.
     Until enough subsequent blocks are added to surpass the <rewrite limit:>, <rollbacks:> are still possible.
 
-When it is not, {{ tutorial.var('is_in_unconfirmed_pool') }} decides whether waiting makes sense.
-A transaction that is neither confirmed nor in the pool is not going to confirm from this node's perspective, so the
-snippet reports it and exits.
+If the transaction is not already part of a block, {{ tutorial.var('is_in_unconfirmed_pool') }} looks for it in the
+unconfirmed pool.
+A transaction that is neither confirmed nor in this pool is reported as not found.
 
-Only when the transaction is waiting in the pool does the snippet call {{ tutorial.var('wait_for_confirmation') }} to
-poll until the transaction is confirmed or the polling window ends.
+Only when the transaction is waiting in the unconfirmed pool does the snippet call
+{{ tutorial.var('wait_for_confirmation') }} to poll until the transaction is confirmed or the polling window ends.
 
 !!! note "Only rejection or a passed deadline means failure"
 
-    There are two ways to be sure a transaction will never confirm: it was rejected at announcement, or its **deadline**
-    has passed.
+    There are only two ways to know a transaction will never confirm: it was rejected when announced, or its
+    **deadline** has passed.
 
-    A transaction dropped from one node's unconfirmed pool may still confirm, because each node keeps its own pool and
-    a peer may still hold it (for example, the node restarted with an empty pool, or evicted the transaction during
-    revalidation).
+    A transaction disappearing from one node's unconfirmed pool does **not** mean it has failed.
+    Each node maintains its own pool, and another peer may still hold and eventually confirm the transaction.
+    For example, a node may restart with an empty pool or remove older transactions while managing pool capacity.
 
-    Since rejections come back in the announcement response, the **deadline** gives the definitive verdict.
-    Once <network time:> passes it, the transaction can no longer enter a block and it is safe to announce a
-    replacement.
+    Because announcement rejections are returned immediately, the **deadline** provides the final verdict.
+    Once <network time:> passes the deadline, the transaction can no longer be included in a block and it is safe
+    to announce a replacement transaction.
 
     Compare the deadline chosen when [building the transaction](./transfer-xem.md#fetching-network-time) against the
-    network time from <get:/time-sync/network-time>.
+    network time returned by <get:/time-sync/network-time>.
 
 ## Output
 
@@ -177,7 +184,7 @@ Some highlights from the output:
 
 * **Transaction hash** (line 2): The hash of the transaction to monitor, which uniquely identifies it on the network.
 
-* **Polling start** (line 4): Polling only starts when the transaction was not confirmed on the first check but was
+* **Polling start** (line 4): Polling starts because the transaction was not already present in the blockchain and was
     found waiting in the unconfirmed pool.
 
 * **Polling attempts** (lines 5-9): Each attempt reports `pending` while the transaction waits to be included in a

--- a/mkdocs/snippets/devbook/transactions/monitoring_status.log
+++ b/mkdocs/snippets/devbook/transactions/monitoring_status.log
@@ -1,0 +1,13 @@
+Using node http://libertalia.nemtest.net:7890
+Monitoring transaction: AE0B2142DFB75C9C126442EF612944E926BCE63FA34B353CDE409E2E87703C0B
+
+Waiting for transaction confirmation
+Polling /transaction/get?hash=AE0B2142DFB75C9C126442EF612944E926BCE63FA34B353CDE409E2E87703C0B
+  Attempt 1: pending
+  Attempt 2: pending
+  Attempt 3: pending
+  Attempt 4: pending
+  Attempt 5: pending
+  Attempt 6: confirmed in block 652601
+
+Transaction confirmed!

--- a/mkdocs/snippets/devbook/transactions/monitoring_status.log
+++ b/mkdocs/snippets/devbook/transactions/monitoring_status.log
@@ -2,7 +2,6 @@ Using node http://libertalia.nemtest.net:7890
 Monitoring transaction: AE0B2142DFB75C9C126442EF612944E926BCE63FA34B353CDE409E2E87703C0B
 
 Waiting for transaction confirmation
-Polling /transaction/get?hash=AE0B2142DFB75C9C126442EF612944E926BCE63FA34B353CDE409E2E87703C0B
   Attempt 1: pending
   Attempt 2: pending
   Attempt 3: pending

--- a/mkdocs/snippets/devbook/transactions/monitoring_status.mjs
+++ b/mkdocs/snippets/devbook/transactions/monitoring_status.mjs
@@ -18,43 +18,21 @@ console.log(`Monitoring transaction: ${transactionHash}`);
 
 // [>step-2]
 /**
- * Poll /transaction/get until the transaction is confirmed.
- * @param {string} txHash - hash of the transaction to monitor
- * @param {number} maxAttempts - maximum polling attempts
- * @param {number} waitSeconds - seconds to wait between attempts
- * @returns {boolean} true if the transaction was confirmed
+ * Query /transaction/get once to check for confirmation.
+ * @param {string} txHash - hash of the transaction to check
+ * @returns {number|null} height of the block containing the
+ *   transaction, or null if it is not confirmed yet
  */
-async function waitForTransactionConfirmation(
-	txHash,
-	maxAttempts = 120,
-	waitSeconds = 1
-) {
-	const statusPath = `/transaction/get?hash=${txHash}`;
-	console.log('\nWaiting for transaction confirmation');
-	console.log(`Polling ${statusPath}`);
-
-	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-		const response = await fetch(`${NODE_URL}${statusPath}`);
-		if (response.ok) {
-			const confirmed = await response.json();
-			console.log(
-				`  Attempt ${attempt}: ` +
-				`confirmed in block ${confirmed.meta.height}`
-			);
-			return true;
-		}
-		if (400 !== response.status)
-			throw new Error(`Unexpected status: ${response.status}`);
-
-		console.log(`  Attempt ${attempt}: pending`);
-		// Wait before next attempt (except on last attempt)
-		if (attempt < maxAttempts) {
-			await new Promise(resolve => {
-				setTimeout(resolve, waitSeconds * 1000);
-			});
-		}
+async function getConfirmationHeight(txHash) {
+	const url = `${NODE_URL}/transaction/get?hash=${txHash}`;
+	const response = await fetch(url);
+	if (response.ok) {
+		const confirmed = await response.json();
+		return confirmed.meta.height;
 	}
-	return false;
+	if (400 !== response.status)
+		throw new Error(`Unexpected status: ${response.status}`);
+	return null;
 } // [<step-2]
 
 // [>step-3]
@@ -77,11 +55,45 @@ async function isInUnconfirmedPool(signature, address) {
 } // [<step-3]
 
 // [>step-4]
-if (await waitForTransactionConfirmation(transactionHash))
-	console.log('\nTransaction confirmed!');
-else if (await isInUnconfirmedPool(transactionSignature, signerAddress))
-	console.log('\nTransaction still in the unconfirmed pool.');
-else
-	console.log('\nTransaction not in the unconfirmed pool.');
+/**
+ * Check for confirmation repeatedly until the transaction is
+ * confirmed or the attempts run out.
+ * @param {string} txHash - hash of the transaction to monitor
+ * @param {number} maxAttempts - maximum polling attempts
+ * @param {number} waitSeconds - seconds to wait between attempts
+ * @returns {boolean} true if the transaction was confirmed
+ */
+async function waitForConfirmation(
+	txHash,
+	maxAttempts = 120,
+	waitSeconds = 1
+) {
+	console.log('\nWaiting for transaction confirmation');
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		await new Promise(resolve => {
+			setTimeout(resolve, waitSeconds * 1000);
+		});
+		const height = await getConfirmationHeight(txHash);
+		const status = height ? `confirmed in block ${height}` : 'pending';
+		console.log(`  Attempt ${attempt}: ${status}`);
+		if (height)
+			return true;
+	}
+	return false;
+} // [<step-4]
 
-// [<step-4]
+// [>step-5]
+try {
+	const blockHeight = await getConfirmationHeight(transactionHash);
+	if (blockHeight)
+		console.log(`\nTransaction already confirmed in block ${blockHeight}`);
+	else if (!(await isInUnconfirmedPool(transactionSignature, signerAddress)))
+		console.log('\nTransaction not in the unconfirmed pool');
+	else if (await waitForConfirmation(transactionHash))
+		console.log('\nTransaction confirmed!');
+	else
+		console.log('\nTransaction not confirmed within the polling window');
+} catch (error) {
+	console.log(`\nCould not reach the node: ${error.message}`);
+}
+// [<step-5]

--- a/mkdocs/snippets/devbook/transactions/monitoring_status.mjs
+++ b/mkdocs/snippets/devbook/transactions/monitoring_status.mjs
@@ -1,0 +1,87 @@
+const NODE_URL = process.env.NODE_URL ||
+	'http://libertalia.nemtest.net:7890';
+console.log('Using node', NODE_URL);
+
+// [>step-1]
+// Transaction hash to monitor.
+const transactionHash = process.env.TRANSACTION_HASH ||
+	'AE0B2142DFB75C9C126442EF612944E926BCE63FA34B353CDE409E2E87703C0B';
+// Signer's address.
+const signerAddress = process.env.SIGNER_ADDRESS ||
+	'TBONKWCOWBZYZB2I5JD3LSDBQVBYHB757VN3SKPP';
+// Transaction signature.
+const transactionSignature = process.env.TRANSACTION_SIGNATURE ||
+	'99B1850FADDB964112D030AA0A5C9F8B5B1B6B992B407D9C70F52F089BD651DF' +
+	'A7D4991639A48B810EFD98C45060D7AD9AE57FDA37F58561459DCE8D0A747F02';
+// [<step-1]
+console.log(`Monitoring transaction: ${transactionHash}`);
+
+// [>step-2]
+/**
+ * Poll /transaction/get until the transaction is confirmed.
+ * @param {string} txHash - hash of the transaction to monitor
+ * @param {number} maxAttempts - maximum polling attempts
+ * @param {number} waitSeconds - seconds to wait between attempts
+ * @returns {boolean} true if the transaction was confirmed
+ */
+async function waitForTransactionConfirmation(
+	txHash,
+	maxAttempts = 120,
+	waitSeconds = 1
+) {
+	const statusPath = `/transaction/get?hash=${txHash}`;
+	console.log('\nWaiting for transaction confirmation');
+	console.log(`Polling ${statusPath}`);
+
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		const response = await fetch(`${NODE_URL}${statusPath}`);
+		if (response.ok) {
+			const confirmed = await response.json();
+			console.log(
+				`  Attempt ${attempt}: ` +
+				`confirmed in block ${confirmed.meta.height}`
+			);
+			return true;
+		}
+		if (400 !== response.status)
+			throw new Error(`Unexpected status: ${response.status}`);
+
+		console.log(`  Attempt ${attempt}: pending`);
+		// Wait before next attempt (except on last attempt)
+		if (attempt < maxAttempts) {
+			await new Promise(resolve => {
+				setTimeout(resolve, waitSeconds * 1000);
+			});
+		}
+	}
+	return false;
+} // [<step-2]
+
+// [>step-3]
+/**
+ * Check whether a transaction with the given signature is in the
+ * address's unconfirmed pool.
+ * @param {string} signature - hex signature of the monitored transaction
+ * @param {string} address - signer's address
+ * @returns {boolean} true if the signature is in the signer's pool
+ */
+async function isInUnconfirmedPool(signature, address) {
+	const path = `/account/unconfirmedTransactions?address=${address}`;
+	const response = await fetch(`${NODE_URL}${path}`);
+	const pool = (await response.json()).data;
+
+	const target = signature.toLowerCase();
+	return pool.some(
+		entry => entry.transaction.signature.toLowerCase() === target
+	);
+} // [<step-3]
+
+// [>step-4]
+if (await waitForTransactionConfirmation(transactionHash))
+	console.log('\nTransaction confirmed!');
+else if (await isInUnconfirmedPool(transactionSignature, signerAddress))
+	console.log('\nTransaction still in the unconfirmed pool.');
+else
+	console.log('\nTransaction not in the unconfirmed pool.');
+
+// [<step-4]

--- a/mkdocs/snippets/devbook/transactions/monitoring_status.mjs
+++ b/mkdocs/snippets/devbook/transactions/monitoring_status.mjs
@@ -74,7 +74,8 @@ async function waitForConfirmation(
 			setTimeout(resolve, waitSeconds * 1000);
 		});
 		const height = await getConfirmationHeight(txHash);
-		const status = height ? `confirmed in block ${height}` : 'pending';
+		const status =
+			height ? `confirmed in block ${height}` : 'pending';
 		console.log(`  Attempt ${attempt}: ${status}`);
 		if (height)
 			return true;
@@ -86,13 +87,14 @@ async function waitForConfirmation(
 try {
 	const blockHeight = await getConfirmationHeight(transactionHash);
 	if (blockHeight)
-		console.log(`\nTransaction already confirmed in block ${blockHeight}`);
-	else if (!(await isInUnconfirmedPool(transactionSignature, signerAddress)))
-		console.log('\nTransaction not in the unconfirmed pool');
+		console.log(`\nTransaction confirmed in block ${blockHeight}`);
+	else if (!(await isInUnconfirmedPool(transactionSignature,
+		signerAddress)))
+		console.log('\nTransaction not found');
 	else if (await waitForConfirmation(transactionHash))
 		console.log('\nTransaction confirmed!');
 	else
-		console.log('\nTransaction not confirmed within the polling window');
+		console.log('\nConfirmation timed out');
 } catch (error) {
 	console.log(`\nCould not reach the node: ${error.message}`);
 }

--- a/mkdocs/snippets/devbook/transactions/monitoring_status.py
+++ b/mkdocs/snippets/devbook/transactions/monitoring_status.py
@@ -25,41 +25,26 @@ transaction_signature = os.getenv(
 print(f"Monitoring transaction: {transaction_hash}")
 
 
-def wait_for_transaction_confirmation(  # [>step-2]
-	tx_hash, max_attempts=120, wait_seconds=1
-):
+def get_confirmation_height(tx_hash):  # [>step-2]
 	"""
-	Poll /transaction/get until the transaction is confirmed.
+	Query /transaction/get once to check for confirmation.
 
 	Args:
-		tx_hash: hash of the transaction to monitor
-		max_attempts: maximum polling attempts
-		wait_seconds: seconds to wait between attempts
+		tx_hash: hash of the transaction to check
 
 	Returns:
-		True if the transaction was confirmed, False otherwise
+		The height of the block containing the transaction, or None
+		if the transaction is not confirmed yet
 	"""
-	status_path = f"/transaction/get?hash={tx_hash}"
-	print("\nWaiting for transaction confirmation")
-	print(f"Polling {status_path}")
-
-	for attempt in range(1, max_attempts + 1):
-		try:
-			url = f"{NODE_URL}{status_path}"
-			with urllib.request.urlopen(url) as response:
-				confirmed = json.loads(response.read().decode())
-				height = confirmed["meta"]["height"]
-				print(f"  Attempt {attempt}: confirmed in block {height}")
-				return True
-		except urllib.error.HTTPError as err:
-			if err.status != 400:
-				raise
-			print(f"  Attempt {attempt}: pending")
-		# Wait before next attempt (except on last attempt)
-		if attempt < max_attempts:
-			time.sleep(wait_seconds)
-	return False
-	# [<step-2]
+	url = f"{NODE_URL}/transaction/get?hash={tx_hash}"
+	try:
+		with urllib.request.urlopen(url) as response:
+			confirmed = json.loads(response.read().decode())
+			return confirmed["meta"]["height"]
+	except urllib.error.HTTPError as err:
+		if err.status != 400:
+			raise
+		return None  # [<step-2]
 
 
 def is_in_unconfirmed_pool(signature, address):  # [>step-3]
@@ -75,15 +60,44 @@ def is_in_unconfirmed_pool(signature, address):  # [>step-3]
 	return any(
 		entry["transaction"]["signature"].lower() == target
 		for entry in pool
-	)
-	# [<step-3]
+	)  # [<step-3]
 
 
-# [>step-4]
-if wait_for_transaction_confirmation(transaction_hash):
-	print("\nTransaction confirmed!")
-elif is_in_unconfirmed_pool(transaction_signature, signer_address):
-	print("\nTransaction still in the unconfirmed pool.")
-else:
-	print("\nTransaction not in the unconfirmed pool.")
-# [<step-4]
+def wait_for_confirmation(  # [>step-4]
+	tx_hash, max_attempts=120, wait_seconds=1
+):
+	"""
+	Check for confirmation repeatedly until the transaction is confirmed or
+	the attempts run out.
+
+	Args:
+		tx_hash: hash of the transaction to monitor
+		max_attempts: maximum polling attempts
+		wait_seconds: seconds to wait between attempts
+
+	Returns:
+		True if the transaction was confirmed, False otherwise
+	"""
+	print("\nWaiting for transaction confirmation")
+	for attempt in range(1, max_attempts + 1):
+		time.sleep(wait_seconds)
+		height = get_confirmation_height(tx_hash)
+		status = f"confirmed in block {height}" if height else "pending"
+		print(f"  Attempt {attempt}: {status}")
+		if height:
+			return True
+	return False  # [<step-4]
+
+
+try:  # [>step-5]
+	block_height = get_confirmation_height(transaction_hash)
+	if block_height:
+		print(f"\nTransaction already confirmed in block {block_height}")
+	elif not is_in_unconfirmed_pool(transaction_signature, signer_address):
+		print("\nTransaction not in the unconfirmed pool")
+	elif wait_for_confirmation(transaction_hash):
+		print("\nTransaction confirmed!")
+	else:
+		print("\nTransaction not confirmed within the polling window")
+except urllib.error.URLError as err:
+	print(f"\nCould not reach the node: {err.reason}")  # [<step-5]

--- a/mkdocs/snippets/devbook/transactions/monitoring_status.py
+++ b/mkdocs/snippets/devbook/transactions/monitoring_status.py
@@ -67,8 +67,8 @@ def wait_for_confirmation(  # [>step-4]
 	tx_hash, max_attempts=120, wait_seconds=1
 ):
 	"""
-	Check for confirmation repeatedly until the transaction is confirmed or
-	the attempts run out.
+	Check for confirmation repeatedly until the transaction is confirmed
+	or the attempts run out.
 
 	Args:
 		tx_hash: hash of the transaction to monitor
@@ -92,9 +92,10 @@ def wait_for_confirmation(  # [>step-4]
 try:  # [>step-5]
 	block_height = get_confirmation_height(transaction_hash)
 	if block_height:
-		print(f"\nTransaction already confirmed in block {block_height}")
-	elif not is_in_unconfirmed_pool(transaction_signature, signer_address):
-		print("\nTransaction not in the unconfirmed pool")
+		print(f"\nTransaction confirmed in block {block_height}")
+	elif not is_in_unconfirmed_pool(transaction_signature,
+			signer_address):
+		print("\nTransaction not found")
 	elif wait_for_confirmation(transaction_hash):
 		print("\nTransaction confirmed!")
 	else:

--- a/mkdocs/snippets/devbook/transactions/monitoring_status.py
+++ b/mkdocs/snippets/devbook/transactions/monitoring_status.py
@@ -1,0 +1,89 @@
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+NODE_URL = os.getenv("NODE_URL", "http://libertalia.nemtest.net:7890")
+print(f'Using node {NODE_URL}')
+
+# [>step-1]
+# Transaction hash to monitor
+transaction_hash = os.getenv(
+	"TRANSACTION_HASH",
+	"AE0B2142DFB75C9C126442EF612944E926BCE63FA34B353CDE409E2E87703C0B")
+# Signer's address
+signer_address = os.getenv(
+	"SIGNER_ADDRESS",
+	"TBONKWCOWBZYZB2I5JD3LSDBQVBYHB757VN3SKPP")
+# Transaction signature
+transaction_signature = os.getenv(
+	"TRANSACTION_SIGNATURE",
+	"99B1850FADDB964112D030AA0A5C9F8B5B1B6B992B407D9C70F52F089BD651DF"
+	"A7D4991639A48B810EFD98C45060D7AD9AE57FDA37F58561459DCE8D0A747F02")
+# [<step-1]
+print(f"Monitoring transaction: {transaction_hash}")
+
+
+def wait_for_transaction_confirmation(  # [>step-2]
+	tx_hash, max_attempts=120, wait_seconds=1
+):
+	"""
+	Poll /transaction/get until the transaction is confirmed.
+
+	Args:
+		tx_hash: hash of the transaction to monitor
+		max_attempts: maximum polling attempts
+		wait_seconds: seconds to wait between attempts
+
+	Returns:
+		True if the transaction was confirmed, False otherwise
+	"""
+	status_path = f"/transaction/get?hash={tx_hash}"
+	print("\nWaiting for transaction confirmation")
+	print(f"Polling {status_path}")
+
+	for attempt in range(1, max_attempts + 1):
+		try:
+			url = f"{NODE_URL}{status_path}"
+			with urllib.request.urlopen(url) as response:
+				confirmed = json.loads(response.read().decode())
+				height = confirmed["meta"]["height"]
+				print(f"  Attempt {attempt}: confirmed in block {height}")
+				return True
+		except urllib.error.HTTPError as err:
+			if err.status != 400:
+				raise
+			print(f"  Attempt {attempt}: pending")
+		# Wait before next attempt (except on last attempt)
+		if attempt < max_attempts:
+			time.sleep(wait_seconds)
+	return False
+	# [<step-2]
+
+
+def is_in_unconfirmed_pool(signature, address):  # [>step-3]
+	"""
+	Check whether a transaction with the given signature is in the
+	address's unconfirmed pool.
+	"""
+	path = f"/account/unconfirmedTransactions?address={address}"
+	with urllib.request.urlopen(f"{NODE_URL}{path}") as response:
+		pool = json.loads(response.read().decode())["data"]
+
+	target = signature.lower()
+	return any(
+		entry["transaction"]["signature"].lower() == target
+		for entry in pool
+	)
+	# [<step-3]
+
+
+# [>step-4]
+if wait_for_transaction_confirmation(transaction_hash):
+	print("\nTransaction confirmed!")
+elif is_in_unconfirmed_pool(transaction_signature, signer_address):
+	print("\nTransaction still in the unconfirmed pool.")
+else:
+	print("\nTransaction not in the unconfirmed pool.")
+# [<step-4]


### PR DESCRIPTION
Adapts the Symbol [Monitoring Transaction Status](https://docs.symboltest.net/en/devbook/transactions/monitoring-status/) tutorial to NEM.

The resulting tutorial is substantially different from Symbol. 

NEM validates transactions at announcement time, so most rejections surface directly in the announce response. Then, tracking if confirmed is more or less trivial with the `/transaction/get` endpoint. 

However, if the transaction does not get confirmed, tracking its status if far more complex than Symbol, because:

- There is no endpoint to know if a transaction left the unconfirmed pool.
- `/account/unconfirmedTransactions` returns at most the 25 most recent entries per address, with no pagination, leading to probable false negatives.
- `/account/unconfirmedTransactions`  response omits transaction hashes, so entries must be matched by signature.

For these reasons, the tutorial focuses on explaining the confirmation flow and the mechanisms NEM does provide, rather than offering a complete reusable status function.  The two takeaways for readers are how to detect that a transaction is confirmed or still pending to be processed, and how to decide that it will not be longer be confirmed (its deadline has passed, so it can never be included in a block).