### PR TITLE
[mkdocs] fix: move tutorial complexity tag

### DIFF
--- a/mkdocs/overrides/partials/actions.html
+++ b/mkdocs/overrides/partials/actions.html
@@ -16,9 +16,4 @@
 			{% include ".icons/" ~ icon ~ ".svg" %}
 		</a>
 	{% endif %}
-	{% if page.meta and page.meta.tutorial_level %}
-	<span class="md-content__button tutorial_level tutorial_level-{{page.meta.tutorial_level}}" title="{{config.extra.nem.tutorial_level}}">
-		{{config.extra.nem.tutorial_level_labels[page.meta.tutorial_level]}}
-	</span>
-	{% endif %}
 {% endif %}

--- a/mkdocs/scripts/hooks.py
+++ b/mkdocs/scripts/hooks.py
@@ -453,12 +453,25 @@ def page_markdown_ws(content, page, config, files):
 	return content
 
 
+def page_markdown_tutorial_complexity_tags(content, page, config, files):
+	if 'tutorial_level' in page.meta:
+		level = page.meta['tutorial_level']
+		tag = (
+			f'<span class="tutorial_level tutorial_level-{level}" title="{config.extra['nem']['tutorial_level']}">'
+			f'{config.extra['nem']['tutorial_level_labels'][level]}'
+			f'</span>'
+		)
+		content = re.sub(r'(^# [^\n]*)', rf'\g<1><br/>{tag}', content)
+	return content
+
+
 @mkdocs.plugins.event_priority(0)
 def on_page_markdown(content, page, config, files):
 	content = page_markdown_js_typedoc(content, page, config, files)
 	content = page_markdown_dylinks(content, page, config, files)
 	content = page_markdown_rest(content, page, config, files)
 	content = page_markdown_ws(content, page, config, files)
+	content = page_markdown_tutorial_complexity_tags(content, page, config, files)
 	return content
 
 


### PR DESCRIPTION
Under the title instead of on the side, so it uses up less space.