### PR TITLE
[mkdocs] docs: improve anchor positioning in tutorials

### DIFF
--- a/mkdocs/overrides/assets/stylesheets/extra.css
+++ b/mkdocs/overrides/assets/stylesheets/extra.css
@@ -640,6 +640,13 @@ code.doc-symbol-interface::after {
 	padding: 0 10px;
 }
 
+.md-typeset h1:has(+ .tutorial_level-container) {
+	margin-bottom: 0.5rem;
+}
+.md-typeset .tutorial_level-container {
+	margin: 0 0 1.2em;
+}
+
 [data-md-color-scheme=slate] .md-typeset .tutorial_level-beginner {
 	background-color: #1F7A3E;
 	color: #B6F2C8;

--- a/mkdocs/scripts/hooks.py
+++ b/mkdocs/scripts/hooks.py
@@ -457,11 +457,13 @@ def page_markdown_tutorial_complexity_tags(content, page, config, files):
 	if 'tutorial_level' in page.meta:
 		level = page.meta['tutorial_level']
 		tag = (
+			f'<div class="tutorial_level-container">'
 			f'<span class="tutorial_level tutorial_level-{level}" title="{config.extra['nem']['tutorial_level']}">'
 			f'{config.extra['nem']['tutorial_level_labels'][level]}'
 			f'</span>'
+			f'</div>'
 		)
-		content = re.sub(r'(^# [^\n]*)', rf'\g<1><br/>{tag}', content)
+		content = re.sub(r'(^# [^\n]*)', rf'\g<1>\n\n{tag}', content)
 	return content
 
 


### PR DESCRIPTION
## Motivation

Moves the anchor icon that appears on hover next to title instead of next to the tutorial level badge in tutorials. Also reduces the spacing between the badge and the main text a bit.


**Before**

<img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/5e831484-e0dd-4c48-bbfb-8e2c40122742" />



**After**

<img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/1436b3dd-4ad0-4fcc-b3a3-35230bc4a69e" />


If looks good, I'll backport it to Symbol.