### PR TITLE
[mkdocs] docs: register and extend root namespace tutorials

### DIFF
--- a/mkdocs/config/mkdocs.en.yml
+++ b/mkdocs/config/mkdocs.en.yml
@@ -94,6 +94,8 @@ nav:
           - Mosaics:
               - devbook/mosaics/get-mosaic-info.md
           - Namespaces:
+              - devbook/namespaces/register-root-namespace.md
+              - devbook/namespaces/extend-root-namespace.md
               - devbook/namespaces/get-namespace-info.md
           - Network Currency:
               - devbook/network-currency/query-currency-supply.md

--- a/mkdocs/pages/en/devbook/mosaics/get-mosaic-info.md
+++ b/mkdocs/pages/en/devbook/mosaics/get-mosaic-info.md
@@ -36,7 +36,7 @@ If not set, it defaults to the <XEM:> mosaic (`nem:xem`).
 
 The <get:/mosaic/definition> endpoint retrieves the definition of a mosaic, including:
 
-* **Description:** Human-readable text [describing](../../textbook/mosaics.md#description) the mosaic.
+* **Description:** Text [describing](../../textbook/mosaics.md#description) the mosaic.
 * **Creator:** The <public key:> of the account that created the mosaic.
 * **Properties:** The mosaic's [behavioral properties](../../textbook/mosaics.md#properties):
     * **[Divisibility](../../textbook/mosaics.md#divisibility):** The number of decimal places the mosaic supports.
@@ -80,7 +80,7 @@ Some highlights from the output:
 
 * **Mosaic ID** (line 5): The XEM mosaic identifier, the fully qualified name `nem:xem`.
 
-* **Description** (line 6): A human-readable label set when the mosaic was created.
+* **Description** (line 6): Text that describes the mosaic, set by its creator.
 
 * **Creator** (line 7): The public key of the account that created the mosaic.
 

--- a/mkdocs/pages/en/devbook/namespaces/extend-root-namespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/extend-root-namespace.md
@@ -26,7 +26,8 @@ You can extend a namespace in two situations:
     The network rejects renewal attempts made earlier than that.
 
 * **During the grace period:** The namespace has expired but is still within the
-    [grace period](../../textbook/namespaces.md#duration).
+    [grace period](../../textbook/namespaces.md#duration), which lasts 43200 blocks (approximately 30 days) after
+    expiration.
     Extending it restores the namespace to active status immediately.
 
 !!! note "Extending Subnamespaces"

--- a/mkdocs/pages/en/devbook/namespaces/extend-root-namespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/extend-root-namespace.md
@@ -1,0 +1,55 @@
+---
+title: Extend Root Namespace
+tutorial_level: beginner
+---
+
+# Extending a Root Namespace
+
+<Root namespaces:> are leased for a limited [duration](../../textbook/namespaces.md#duration) of approximately one year
+per registration.
+If you want to keep a namespace beyond its initial lease, you need to extend it.
+
+This tutorial shows how to extend a root namespace.
+
+## Prerequisites
+
+* An <account:> that owns an active root namespace.
+    See [Registering a Root Namespace](./register-root-namespace.md).
+* <XEM:> to pay for the transaction and lease fees.
+
+## When to Extend
+
+You can extend a namespace in two situations:
+
+* **Near the end of the lease:** Renewal is only allowed during the final 43200 blocks (approximately 30 days) before
+    expiration.
+    The network rejects renewal attempts made earlier than that.
+
+* **During the grace period:** The namespace has expired but is still within the
+    [grace period](../../textbook/namespaces.md#duration).
+    Extending it restores the namespace to active status immediately.
+
+!!! note "Extending Subnamespaces"
+
+    Only root namespaces need to be extended.
+    <Subnamespaces:> inherit the duration of their root namespace, so when you extend a root namespace, all its
+    subnamespaces are automatically extended as well.
+
+## Procedure
+
+To extend a namespace, repeat the [registration process](./register-root-namespace.md) using the
+**same root namespace name** and pay the **100 XEM lease fee** again.
+
+The account signing the transaction must be the namespace owner.
+
+The protocol accepts renewals only [near the end of the lease or during the grace period](#when-to-extend).
+
+## Duration and Limits
+
+Each renewal extends the lease to one year after the block containing the renewal transaction, not one year after the
+previous expiration.
+As a consequence, a namespace cannot be prepaid for multiple years in advance.
+
+To maintain a namespace indefinitely, renew it during the renewal window every year.
+
+For more details, see [Duration](../../textbook/namespaces.md#duration) in the Textbook.

--- a/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
@@ -1,0 +1,150 @@
+---
+title: Register Root Namespace
+tutorial_level: intermediate
+---
+
+# Registering a Root Namespace
+
+<Namespaces:|Namespaces> provide human-readable spaces that group related <mosaics:> under a meaningful name, like the
+`nem` prefix in the native `nem:xem` mosaic.
+
+This tutorial shows how to register a <root namespace:> for one year.
+
+## Prerequisites
+
+Before you start, make sure to:
+
+* Set up your development environment.
+  See [Setting Up a Development Environment](../start/setup.md).
+* Create an <account:> to register the namespace, either [from code](../accounts/create-from-private-key.md) or
+  [by using a wallet](../../userbook/wallet/create-account.md).
+* Obtain <XEM:> to pay for the transaction and lease fees.
+  See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
+
+Additionally, review the [Transfer XEM](../transactions/transfer-xem.md) tutorial to understand how transactions are
+announced and confirmed.
+
+## Full Code
+
+{% import 'tutorial.jinja2' as tutorial with context %}
+
+{{ tutorial.code_full_tagged('devbook/namespaces/register_root_namespace', ['py', 'js']) }}
+
+## Code Explanation
+
+### Setting Up the Account
+
+{{ tutorial.code_snippet_tagged('step-1') }}
+
+The snippet reads the signer's private key from the `SIGNER_PRIVATE_KEY` environment variable, which defaults to a test
+key if not set.
+The signer's address is derived from the public key.
+This account will own the registered namespace.
+
+### Fetching Network Time
+
+{{ tutorial.code_snippet_tagged('step-2') }}
+
+Network time is fetched from <get:/time-sync/network-time>, and the transaction's `timestamp` and `deadline` fields
+are derived from it, following the process described in the [Transfer XEM](../transactions/transfer-xem.md) tutorial.
+
+### Building the Transaction
+
+{{ tutorial.code_snippet_tagged('step-3') }}
+
+A namespace is identified by its name, which the transaction registers on the network for one year.
+
+The namespace registration transaction specifies:
+
+* {{ tutorial.var('type') }}: Namespace registration transactions use the type <ser:NamespaceRegistrationTransactionV1>.
+
+* {{ tutorial.var('signer_public_key') }}: The account that signs the transaction and pays the fees.
+    It becomes the owner of the registered namespace.
+
+* {{ tutorial.var('timestamp') }} and {{ tutorial.var('deadline') }}: The values computed in the network time step.
+
+* {{ tutorial.var('rental_fee_sink') }}: The special account that collects namespace
+    [lease fees](../../textbook/namespaces.md#lease-fee).
+    Each network has a fixed sink address:
+
+    * <mainnet:>: `NAMESPACEWH4MKFMBCVFERDPOOP4FK7MTBXDPZZA`
+    * <testnet:>: `TAMESPACEWH4MKFMBCVFERDPOOP4FK7MTDJEYP35`
+
+    The network rejects transactions that send the lease fee to any other address.
+
+* {{ tutorial.var('rental_fee') }}: The lease fee, which is 100 XEM for root namespaces.
+    The SDK's <dy:FeeCalculator.calculateNamespaceRentalFee> helper returns the required amount.
+    The {{ tutorial.lit('True') }} argument requests the fee for a root namespace.
+
+    The network rejects transactions that pay less than the minimum fee.
+    Larger amounts are accepted, but the entire amount is transferred to the sink account.
+
+* {{ tutorial.var('name') }}: The name of the root namespace.
+    Names can only contain lowercase letters, numbers, hyphens, and underscores, must start with a letter or number,
+    and root names can be at most 16 characters long.
+
+    To ensure the namespace name is unique across multiple runs of the tutorial, a timestamp is added to the name.
+    In practice, programs would use a fixed name for their namespaces.
+
+Finally, the transaction fee is calculated with <dy:FeeCalculator.calculateTransactionFee> and attached to the
+transaction.
+Unlike the lease fee, the transaction fee is paid to the <harvester account:>.
+Namespace registration transactions pay a fixed transaction fee of 0.15 XEM, as shown in the
+[fee schedule](../../textbook/transactions.md#fee-schedule).
+
+### Submitting the Transaction
+
+{{ tutorial.code_snippet_tagged('step-4') }}
+
+The transaction is signed and announced following the same process as in
+[Transfer XEM](../transactions/transfer-xem.md#announcing-the-transaction).
+
+{{ tutorial.code_snippet_tagged('step-5') }}
+
+The code then waits for the transaction to be confirmed by polling the <get:/transaction/get> endpoint until the
+transaction is included in a block.
+
+### Retrieving the Namespace
+
+{{ tutorial.code_snippet_tagged('step-6') }}
+
+To verify the namespace was registered, the code retrieves it from the network using the <get:/namespace> endpoint and
+displays its properties.
+
+A successful response confirms that the namespace is registered and active.
+
+## Output
+
+The output shown below corresponds to a typical run of the program.
+
+```text linenums="1" hl_lines="5 6 7 31-33"
+--8<-- 'devbook/namespaces/register_root_namespace.log'
+```
+
+Some highlights from the output:
+
+* **Namespace name** (line 5): The chosen name `ns_1783091378` includes a timestamp to ensure uniqueness.
+    Search for this name in the [NEM testnet explorer](https://testnet.nem.fyi/) to view the namespace details.
+
+* **Lease fee and transaction fee** (lines 6-7): The lease fee is 100 XEM, while the transaction fee is a flat 0.15 XEM.
+
+* **Namespace information** (lines 31-33): The registered namespace, its owner (the signer's address), and the block
+    height at which the lease began.
+
+## Conclusion
+
+This tutorial showed how to:
+
+| Step                                                                     | Related documentation                          |
+|--------------------------------------------------------------------------|------------------------------------------------|
+| [Build a namespace registration transaction](#building-the-transaction)  | <dy:TransactionFactory.create>                 |
+| [Calculate the lease fee](#building-the-transaction)                     | <dy:FeeCalculator.calculateNamespaceRentalFee> |
+| [Retrieve the namespace](#retrieving-the-namespace)                      | <get:/namespace>                               |
+
+## Next Steps
+
+Now that you have a root namespace, you can:
+
+* [Define mosaics](../mosaics/create-mosaic.md) under the namespace to create custom assets
+* [Register a subnamespace](./register-subnamespace.md) to create a hierarchical structure
+* [Extend the namespace](./extend-root-namespace.md) before it expires to keep it active

--- a/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
@@ -5,10 +5,11 @@ tutorial_level: intermediate
 
 # Registering a Root Namespace
 
-<Namespaces:|Namespaces> provide human-readable spaces that group related <mosaics:> under a meaningful name, like the
-`nem` prefix in the native `nem:xem` mosaic.
+<Namespaces:|Namespaces> provide labels that group related <mosaics:> under a meaningful name, like the `nem` prefix
+in the native `nem:xem` mosaic.
 
-This tutorial shows how to register a <root namespace:> for one year.
+Namespaces can be nested under other namespaces, and this tutorial shows how to register a <root namespace:> for one
+year.
 
 ## Prerequisites
 
@@ -76,12 +77,11 @@ The namespace registration transaction specifies:
     The SDK's <dy:FeeCalculator.calculateNamespaceRentalFee> helper returns the required amount.
     The {{ tutorial.lit('True') }} argument requests the fee for a root namespace.
 
-    The network rejects transactions that pay less than the minimum fee.
+    The network rejects transactions that pay less than this fee.
     Larger amounts are accepted, but the entire amount is transferred to the sink account.
 
 * {{ tutorial.var('name') }}: The name of the root namespace.
-    Names can only contain lowercase letters, numbers, hyphens, and underscores, must start with a letter or number,
-    and root names can be at most 16 characters long.
+    See [Name](../../textbook/namespaces.md#name) in the Textbook for the naming rules.
 
     To ensure the namespace name is unique across multiple runs of the tutorial, a timestamp is added to the name.
     In practice, programs would use a fixed name for their namespaces.
@@ -96,8 +96,8 @@ Namespace registration transactions pay a fixed transaction fee of 0.15 XEM, as 
 
 {{ tutorial.code_snippet_tagged('step-4') }}
 
-The transaction is signed and announced following the same process as in
-[Transfer XEM](../transactions/transfer-xem.md#announcing-the-transaction).
+The transaction is signed and announced following the same process as in the
+[Transfer XEM](../transactions/transfer-xem.md#announcing-the-transaction) tutorial.
 
 {{ tutorial.code_snippet_tagged('step-5') }}
 
@@ -110,6 +110,7 @@ transaction is included in a block.
 
 To verify the namespace was registered, the code retrieves it from the network using the <get:/namespace> endpoint and
 displays its properties.
+The registration height is the block in which the namespace was registered, marking the start of the one-year lease.
 
 A successful response confirms that the namespace is registered and active.
 
@@ -126,10 +127,11 @@ Some highlights from the output:
 * **Namespace name** (line 5): The chosen name `ns_1783091378` includes a timestamp to ensure uniqueness.
     Search for this name in the [NEM testnet explorer](https://testnet.nem.fyi/) to view the namespace details.
 
-* **Lease fee and transaction fee** (lines 6-7): The lease fee is 100 XEM, while the transaction fee is a flat 0.15 XEM.
+* **Lease fee and transaction fee** (lines 6-7): The lease fee is 100 XEM because this is a root namespace
+    (<subnamespaces:> pay 10 XEM instead), while the transaction fee is 0.15 XEM.
 
-* **Namespace information** (lines 31-33): The registered namespace, its owner (the signer's address), and the block
-    height at which the lease began.
+* **Namespace information** (lines 31-33): The registered namespace, its owner (the signer's address), and the
+    registration height, which is the block at which the lease began.
 
 ## Conclusion
 

--- a/mkdocs/pages/en/devbook/transactions/monitoring-status.md
+++ b/mkdocs/pages/en/devbook/transactions/monitoring-status.md
@@ -14,7 +14,7 @@ This tutorial shows how to poll a transaction's status until it is confirmed, ho
 waiting in the <unconfirmed pool:>, and how to decide when it will never confirm.
 
 This kind of monitoring typically happens right after announcing a transaction, as shown in the
-[Transfer XEM tutorial](./transfer-xem.md), to make sure it gets confirmed.
+[Transfer XEM](./transfer-xem.md) tutorial, to make sure it gets confirmed.
 
 !!! note "Polling is not recommended for production"
 
@@ -65,7 +65,7 @@ Neither is needed to detect confirmation, but both are used to check whether a t
 
 The snippet uses sample values.
 Set `TRANSACTION_HASH`, `SIGNER_ADDRESS`, and `TRANSACTION_SIGNATURE` environment variables to override them.
-All three values are produced when signing a transaction, as shown in the [Transfer XEM tutorial](./transfer-xem.md).
+All three values are produced when signing a transaction, as shown in the [Transfer XEM](./transfer-xem.md) tutorial.
 
 ### Checking for Confirmation
 
@@ -107,7 +107,7 @@ reports whether the monitored transaction is among the pending list.
 
     A transaction that fails [validation](../../textbook/transactions.md#3-validation) does not reach the unconfirmed
     pool: the receiving <node:> rejects it immediately when announced, as shown in the
-    [Transfer XEM tutorial](./transfer-xem.md#announcing-the-transaction).
+    [Transfer XEM](./transfer-xem.md#announcing-the-transaction) tutorial.
 
 The above endpoint response omits each entry's hash, so the function matches by **signature** instead.
 A transaction's signature is unique and appears under `transaction.signature` in every pool entry.

--- a/mkdocs/pages/en/devbook/websockets/listen-transaction-flow.md
+++ b/mkdocs/pages/en/devbook/websockets/listen-transaction-flow.md
@@ -127,7 +127,7 @@ This tutorial builds a minimal <Transfer Transaction:> to the monitored address,
 A transfer is used for simplicity, but any transaction type triggers the same WebSocket notifications.
 
 The transaction follows the same process described in the
-[Transfer Transaction tutorial](../transactions/transfer-xem.md): fetching the network time, creating the transaction,
+[Transfer XEM](../transactions/transfer-xem.md) tutorial: fetching the network time, creating the transaction,
 and signing it.
 The hash is computed locally so it can be matched against incoming messages later.
 

--- a/mkdocs/snippets/devbook/namespaces/register_root_namespace.log
+++ b/mkdocs/snippets/devbook/namespaces/register_root_namespace.log
@@ -30,4 +30,4 @@ Fetching namespace information from /namespace?namespace=ns_1783091378
 Namespace information:
   Name: ns_1783091378
   Owner: TBONKWCOWBZYZB2I5JD3LSDBQVBYHB757VN3SKPP
-  Height: 685363
+  Registration height: 685363

--- a/mkdocs/snippets/devbook/namespaces/register_root_namespace.log
+++ b/mkdocs/snippets/devbook/namespaces/register_root_namespace.log
@@ -1,0 +1,33 @@
+Using node http://libertalia.nemtest.net:7890
+Signer address: TBONKWCOWBZYZB2I5JD3LSDBQVBYHB757VN3SKPP
+Fetching current network time from /time-sync/network-time
+  Network time: 355503793 s since the nemesis block
+Creating root namespace: ns_1783091378
+  Namespace lease fee: 100.0 XEM
+  Transaction fee: 0.15 XEM
+Built transaction:
+{
+  "type": 8193,
+  "version": 1,
+  "network": 152,
+  "timestamp": 355503793,
+  "signer_public_key": "462EE976890916E54FA825D26BDD0235F5EB5B6A143C199AB0AE5EE9328E08CE",
+  "signature": "D15220D1888AC85CE205D4D2B1AF3540CA415716DD266A29646FE0DEFAFBED924F0B698C4F6EEAA706AA836FA82516552D54B5BCE91D841D6F1C865633EED50D",
+  "fee": "150000",
+  "deadline": 355510993,
+  "rental_fee_sink": "54414D4553504143455748344D4B464D42435646455244504F4F5034464B374D54444A4559503335",
+  "rental_fee": "100000000",
+  "name": "6e735f31373833303931333738"
+}
+Announcing namespace registration to /transaction/announce
+  Result: SUCCESS
+Waiting for confirmation from /transaction/get?hash=D56EDC5946F1A41304CDDC2BC322793C558DFB57831EF7D45024DE46D6AD827F
+  Transaction status: pending
+  Transaction status: pending
+  Transaction status: pending
+Transaction confirmed in block 685363
+Fetching namespace information from /namespace?namespace=ns_1783091378
+Namespace information:
+  Name: ns_1783091378
+  Owner: TBONKWCOWBZYZB2I5JD3LSDBQVBYHB757VN3SKPP
+  Height: 685363

--- a/mkdocs/snippets/devbook/namespaces/register_root_namespace.mjs
+++ b/mkdocs/snippets/devbook/namespaces/register_root_namespace.mjs
@@ -109,7 +109,7 @@ try {
 	console.log('Namespace information:');
 	console.log('  Name:', namespaceInfo.fqn);
 	console.log('  Owner:', namespaceInfo.owner);
-	console.log('  Height:', namespaceInfo.height);
+	console.log('  Registration height:', namespaceInfo.height);
 	// [<step-6]
 } catch (e) {
 	console.error(e.message, '| Cause:', e.cause?.code ?? 'unknown');

--- a/mkdocs/snippets/devbook/namespaces/register_root_namespace.mjs
+++ b/mkdocs/snippets/devbook/namespaces/register_root_namespace.mjs
@@ -1,0 +1,116 @@
+import { PrivateKey } from 'symbol-sdk';
+import {
+	NemFacade,
+	calculateNamespaceRentalFee,
+	calculateTransactionFee,
+	models
+} from 'symbol-sdk/nem';
+
+const NODE_URL = process.env.NODE_URL ||
+	'http://libertalia.nemtest.net:7890';
+console.log('Using node', NODE_URL);
+// [>step-1]
+const SIGNER_PRIVATE_KEY = process.env.SIGNER_PRIVATE_KEY ||
+	'0000000000000000000000000000000000000000000000000000000000000000';
+const signerKeyPair = new NemFacade.KeyPair(
+	new PrivateKey(SIGNER_PRIVATE_KEY));
+
+const facade = new NemFacade('testnet');
+const signerAddress = facade.network.publicKeyToAddress(
+	signerKeyPair.publicKey);
+console.log('Signer address:', signerAddress.toString());
+// [<step-1]
+try {
+	// Fetch current network time [>step-2]
+	const timePath = '/time-sync/network-time';
+	console.log('Fetching current network time from', timePath);
+	const timeResponse = await fetch(`${NODE_URL}${timePath}`);
+	const timeJSON = await timeResponse.json();
+	const networkTime = Math.floor(timeJSON.receiveTimeStamp / 1000);
+	console.log('  Network time:', networkTime,
+		's since the nemesis block');
+
+	// Derived fields from network time
+	const timestamp = networkTime;
+	const deadline = networkTime + (2 * 60 * 60);
+	// [<step-2]
+	// Build the transaction [>step-3]
+	const namespaceName = `ns_${Math.floor(Date.now() / 1000)}`;
+	console.log('Creating root namespace:', namespaceName);
+
+	const rentalFee = calculateNamespaceRentalFee(true);
+	console.log('  Namespace lease fee:',
+		`${Number(rentalFee) / 1_000_000} XEM`);
+
+	const transaction = facade.transactionFactory.create({
+		type: 'namespace_registration_transaction_v1',
+		signerPublicKey: signerKeyPair.publicKey.toString(),
+		timestamp,
+		deadline,
+		rentalFeeSink: 'TAMESPACEWH4MKFMBCVFERDPOOP4FK7MTDJEYP35',
+		rentalFee,
+		name: namespaceName
+	});
+
+	const fee = calculateTransactionFee(transaction);
+	transaction.fee = new models.Amount(fee);
+	console.log(`  Transaction fee: ${Number(fee) / 1_000_000} XEM`);
+	// [<step-3]
+	// Sign transaction and generate final payload [>step-4]
+	const signature = facade.signTransaction(signerKeyPair, transaction);
+	const jsonPayload = facade.transactionFactory.static.attachSignature(
+		transaction, signature);
+	console.log('Built transaction:');
+	console.dir(transaction.toJson(), { colors: true });
+
+	// Announce the transaction
+	const announcePath = '/transaction/announce';
+	console.log('Announcing namespace registration to', announcePath);
+	const announceResponse = await fetch(`${NODE_URL}${announcePath}`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: jsonPayload
+	});
+	const announceResult = await announceResponse.json();
+	console.log('  Result:', announceResult.message);
+	// [<step-4]
+	// Wait for confirmation [>step-5]
+	if ('SUCCESS' === announceResult.message) {
+		const transactionHash = facade.hashTransaction(transaction)
+			.toString();
+		const statusPath = `/transaction/get?hash=${transactionHash}`;
+		console.log('Waiting for confirmation from', statusPath);
+
+		let isConfirmed = false;
+		for (let attempt = 1; 120 >= attempt; ++attempt) {
+			const response = await fetch(`${NODE_URL}${statusPath}`);
+
+			if (response.ok) {
+				const confirmed = await response.json();
+				console.log('Transaction confirmed in block',
+					confirmed.meta.height);
+				isConfirmed = true;
+				break;
+			}
+			console.log('  Transaction status: pending');
+			await new Promise(resolve => { setTimeout(resolve, 1000); });
+		}
+		if (!isConfirmed)
+			console.warn('Confirmation took too long.');
+	} else {
+		console.log('Transaction rejected:', announceResult.message);
+	}
+	// [<step-5]
+	// Retrieve the namespace [>step-6]
+	const namespacePath = `/namespace?namespace=${namespaceName}`;
+	console.log('Fetching namespace information from', namespacePath);
+	const namespaceResponse = await fetch(`${NODE_URL}${namespacePath}`);
+	const namespaceInfo = await namespaceResponse.json();
+	console.log('Namespace information:');
+	console.log('  Name:', namespaceInfo.fqn);
+	console.log('  Owner:', namespaceInfo.owner);
+	console.log('  Height:', namespaceInfo.height);
+	// [<step-6]
+} catch (e) {
+	console.error(e.message, '| Cause:', e.cause?.code ?? 'unknown');
+}

--- a/mkdocs/snippets/devbook/namespaces/register_root_namespace.py
+++ b/mkdocs/snippets/devbook/namespaces/register_root_namespace.py
@@ -1,0 +1,119 @@
+import json
+import os
+import time
+import urllib.request
+
+from symbolchain.CryptoTypes import PrivateKey
+from symbolchain.facade.NemFacade import NemFacade
+from symbolchain.nc import Amount
+from symbolchain.nem.FeeCalculator import (
+	calculate_namespace_rental_fee,
+	calculate_transaction_fee
+)
+
+NODE_URL = os.getenv('NODE_URL', 'http://libertalia.nemtest.net:7890')
+print(f'Using node {NODE_URL}')
+# [>step-1]
+SIGNER_PRIVATE_KEY = os.getenv(
+	'SIGNER_PRIVATE_KEY',
+	'0000000000000000000000000000000000000000000000000000000000000000')
+signer_key_pair = NemFacade.KeyPair(PrivateKey(SIGNER_PRIVATE_KEY))
+
+facade = NemFacade('testnet')
+signer_address = facade.network.public_key_to_address(
+	signer_key_pair.public_key)
+print(f'Signer address: {signer_address}')
+# [<step-1]
+try:
+	# Fetch current network time [>step-2]
+	time_path = '/time-sync/network-time'
+	print(f'Fetching current network time from {time_path}')
+	with urllib.request.urlopen(f'{NODE_URL}{time_path}') as response:
+		response_json = json.loads(response.read().decode())
+		network_time = response_json['receiveTimeStamp'] // 1000
+		print(f'  Network time: {network_time} s since the nemesis block')
+
+	# Derived fields from network time
+	timestamp = network_time
+	deadline = network_time + 2 * 60 * 60
+	# [<step-2]
+	# Build the transaction [>step-3]
+	namespace_name = f'ns_{int(time.time())}'
+	print(f'Creating root namespace: {namespace_name}')
+
+	rental_fee = calculate_namespace_rental_fee(True)
+	print(f'  Namespace lease fee: {rental_fee / 1_000_000} XEM')
+
+	transaction = facade.transaction_factory.create({
+		'type': 'namespace_registration_transaction_v1',
+		'signer_public_key': signer_key_pair.public_key,
+		'timestamp': timestamp,
+		'deadline': deadline,
+		'rental_fee_sink': 'TAMESPACEWH4MKFMBCVFERDPOOP4FK7MTDJEYP35',
+		'rental_fee': rental_fee,
+		'name': namespace_name
+	})
+
+	fee = calculate_transaction_fee(transaction)
+	transaction.fee = Amount(fee)
+	print(f'  Transaction fee: {fee / 1_000_000} XEM')
+	# [<step-3]
+	# Sign transaction and generate final payload [>step-4]
+	signature = facade.sign_transaction(signer_key_pair, transaction)
+	json_payload = facade.transaction_factory.attach_signature(
+		transaction, signature)
+	print('Built transaction:')
+	print(json.dumps(transaction.to_json(), indent=2))
+
+	# Announce the transaction
+	announce_path = '/transaction/announce'
+	print(f'Announcing namespace registration to {announce_path}')
+	announce_request = urllib.request.Request(
+		f'{NODE_URL}{announce_path}',
+		data=json_payload.encode(),
+		headers={'Content-Type': 'application/json'},
+		method='POST'
+	)
+	with urllib.request.urlopen(announce_request) as response:
+		announce_result = json.loads(response.read().decode())
+	print(f'  Result: {announce_result['message']}')
+	# [<step-4]
+	# Wait for confirmation [>step-5]
+	if 'SUCCESS' == announce_result['message']:
+		status_path = (
+			f'/transaction/get?hash={
+				facade.hash_transaction(transaction)}')
+		print(f'Waiting for confirmation from {status_path}')
+		is_confirmed = False
+		for attempt in range(120):
+			try:
+				with urllib.request.urlopen(
+					f'{NODE_URL}{status_path}'
+				) as response:
+					confirmed = json.loads(response.read().decode())
+					height = confirmed['meta']['height']
+					print(f'Transaction confirmed in block {height}')
+					is_confirmed = True
+					break
+			except urllib.error.HTTPError:
+				print('  Transaction status: pending')
+			time.sleep(1)
+		if not is_confirmed:
+			print('Confirmation took too long.')
+	else:
+		print(f'Transaction rejected: {announce_result['message']}')
+	# [<step-5]
+	# Retrieve the namespace [>step-6]
+	namespace_path = f'/namespace?namespace={namespace_name}'
+	print(f'Fetching namespace information from {namespace_path}')
+	with urllib.request.urlopen(
+		f'{NODE_URL}{namespace_path}'
+	) as response:
+		namespace_info = json.loads(response.read().decode())
+		print('Namespace information:')
+		print(f'  Name: {namespace_info["fqn"]}')
+		print(f'  Owner: {namespace_info["owner"]}')
+		print(f'  Height: {namespace_info["height"]}')
+	# [<step-6]
+except urllib.error.URLError as e:
+	print(e.reason)

--- a/mkdocs/snippets/devbook/namespaces/register_root_namespace.py
+++ b/mkdocs/snippets/devbook/namespaces/register_root_namespace.py
@@ -113,7 +113,7 @@ try:
 		print('Namespace information:')
 		print(f'  Name: {namespace_info["fqn"]}')
 		print(f'  Owner: {namespace_info["owner"]}')
-		print(f'  Height: {namespace_info["height"]}')
+		print(f'  Registration height: {namespace_info["height"]}')
 	# [<step-6]
 except urllib.error.URLError as e:
 	print(e.reason)


### PR DESCRIPTION
Adapts [Register root namespace](https://docs.symboltest.net/en/devbook/namespaces/register-root-namespace/) and [Extend root namespace](https://docs.symboltest.net/en/devbook/namespaces/extend-root-namespace/) to NEM.