### PR TITLE
[mkdocs] fix: compute circulating supply with integer math

### DIFF
--- a/mkdocs/pages/en/devbook/network-currency/query-currency-supply.md
+++ b/mkdocs/pages/en/devbook/network-currency/query-currency-supply.md
@@ -73,16 +73,24 @@ A portion of the total supply is held by accounts that are not part of the open 
 * **Mosaic rental sink:** Collects the fees paid to create <mosaics:>.
 
 The code queries each account with the <get:/account/get> endpoint and sums their balances.
-Each balance is divided by 10^divisibility^, using the divisibility value fetched in the previous step, to convert it
-from atomic units to whole units.
-For `nem:xem`, this divisor is 1'000'000.
+
+The balances are added up in atomic units.
+They are only converted to whole XEM when printed: dividing by `scale` (1'000'000 for `nem:xem`) gives the whole part,
+and the remainder gives the 6 decimal digits.
+
+Doing this with a regular division instead would produce a float, and these balances are so large that a float can get
+the last digit wrong.
 
 ### Deriving the Circulating Supply
 
 {{ tutorial.code_snippet_tagged('step-4') }}
 
 The circulating supply is the total supply minus the non-circulating balances.
+
 This is the amount of XEM that is freely available on the open market.
+
+The total supply from <get:/mosaic/supply> is in whole units, so the code multiplies it by `scale` to bring it
+to atomic units before subtracting, then prints the result.
 
 ## Output
 

--- a/mkdocs/snippets/devbook/network-currency/query_currency_supply.mjs
+++ b/mkdocs/snippets/devbook/network-currency/query_currency_supply.mjs
@@ -23,31 +23,37 @@ try {
 	const divisibility = parseInt(properties.divisibility, 10);
 	// [<step-2]
 	// [>step-3]
+	const scale = 10n ** BigInt(divisibility);
+
+	const fmtAtomic = atomic =>
+		`${(atomic / scale).toLocaleString('en-US')}.` +
+		`${(atomic % scale).toString().padStart(divisibility, '0')}`;
+
 	const NON_CIRCULATING_ADDRESSES = [
 		['Treasury', 'NCHESTYVD2P6P646AMY7WSNG73PCPZDUQNSD6JAK'],
 		['Nemesis', 'NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'],
 		['Namespace rental', 'NAMESPACEWH4MKFMBCVFERDPOOP4FK7MTBXDPZZA'],
 		['Mosaic rental', 'NBMOSAICOD4F54EE5CDMR23CCBGOAM2XSIUX6TRS']
 	];
-	let nonCirculatingSupply = 0;
+	let nonCirculatingSupply = 0n;
 	for (const [label, address] of NON_CIRCULATING_ADDRESSES) {
 		const accountPath = `/account/get?address=${address}`;
 		const accountResponse = await fetch(`${NODE_URL}${accountPath}`);
 		const accountInfo = await accountResponse.json();
-		const balance =
-			accountInfo.account.balance / (10 ** divisibility);
+		const balance = BigInt(accountInfo.account.balance);
 		nonCirculatingSupply += balance;
-		console.log(`  ${label}: ${fmt(balance)} ${MOSAIC_ID}`);
+		console.log(`  ${label}: ${fmtAtomic(balance)} ${MOSAIC_ID}`);
 	}
 	console.log(
 		'Non-circulating supply: ' +
-		`${fmt(nonCirculatingSupply)} ${MOSAIC_ID}`
+		`${fmtAtomic(nonCirculatingSupply)} ${MOSAIC_ID}`
 	); // [<step-3]
 	// [>step-4]
-	const circulatingSupply = totalSupply - nonCirculatingSupply;
+	const circulatingSupply =
+		(BigInt(totalSupply) * scale) - nonCirculatingSupply;
 	console.log(
 		'Circulating supply: ' +
-		`${fmt(circulatingSupply)} ${MOSAIC_ID}`
+		`${fmtAtomic(circulatingSupply)} ${MOSAIC_ID}`
 	); // [<step-4]
 } catch (error) {
 	console.log(error);

--- a/mkdocs/snippets/devbook/network-currency/query_currency_supply.py
+++ b/mkdocs/snippets/devbook/network-currency/query_currency_supply.py
@@ -25,6 +25,11 @@ try:
 	divisibility = int(properties['divisibility'])
 	# [<step-2]
 	# [>step-3]
+	scale = 10 ** divisibility
+
+	def fmt_atomic(atomic):
+		return f'{atomic // scale:,}.{atomic % scale:0{divisibility}d}'
+
 	NON_CIRCULATING_ADDRESSES = [
 		('Treasury', 'NCHESTYVD2P6P646AMY7WSNG73PCPZDUQNSD6JAK'),
 		('Nemesis', 'NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'),
@@ -38,15 +43,14 @@ try:
 			f'{NODE_URL}{account_path}'
 		) as response:
 			account_info = json.loads(response.read().decode())
-		balance = (account_info['account']['balance']
-			/ (10 ** divisibility))
+		balance = account_info['account']['balance']
 		non_circulating_supply += balance
-		print(f'  {label}: {balance:,.6f} {MOSAIC_ID}')
+		print(f'  {label}: {fmt_atomic(balance)} {MOSAIC_ID}')
 	print(
 		f'Non-circulating supply: '
-		f'{non_circulating_supply:,.6f} {MOSAIC_ID}')  # [<step-3]
+		f'{fmt_atomic(non_circulating_supply)} {MOSAIC_ID}')  # [<step-3]
 	# [>step-4]
-	circulating_supply = total_supply - non_circulating_supply
-	print(f'Circulating supply: {circulating_supply:,.6f} {MOSAIC_ID}')  # [<step-4]
+	circulating_supply = total_supply * scale - non_circulating_supply
+	print(f'Circulating supply: {fmt_atomic(circulating_supply)} {MOSAIC_ID}')  # [<step-4]
 except Exception as error:
 	print(error)


### PR DESCRIPTION
## Problem

The query-currency-supply tutorial converts each non-circulating account balance from microXEM to whole XEM using floating-point division. It then adds those values and subtracts the result from the total supply.

Because the balances are large, for example, the treasury holds about 1.4 × 10¹⁵ microXEM, floating-point rounding can affect the converted values. Subtracting two nearly equal numbers can amplify that rounding error and change the final decimal digit of the displayed circulating supply.

## Solution

Keep all balances in atomic units throughout the calculation. Use `BigInt` in JavaScript or `int` in Python to add the non-circulating balances and subtract them from the total supply as integers.

Convert the final result to whole XEM only for display, using integer division and modulo to format the whole and fractional parts.